### PR TITLE
Update GetSegments.java

### DIFF
--- a/src/main/java/brevoModel/GetSegments.java
+++ b/src/main/java/brevoModel/GetSegments.java
@@ -17,18 +17,20 @@ import com.google.gson.annotations.SerializedName;
 import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang3.ObjectUtils;
 
+import java.util.List;
+
 /**
  * GetSegments
  */
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2024-04-17T12:57:43.398+05:30")
 public class GetSegments {
   @SerializedName("segments")
-  private GetSegmentsSegments segments = null;
+  private List<GetSegmentsSegments> segments = null;
 
   @SerializedName("count")
   private Long count = null;
 
-  public GetSegments segments(GetSegmentsSegments segments) {
+  public GetSegments segments(List<GetSegmentsSegments> segments) {
     this.segments = segments;
     return this;
   }
@@ -38,11 +40,11 @@ public class GetSegments {
    * @return segments
   **/
   @ApiModelProperty(value = "")
-  public GetSegmentsSegments getSegments() {
+  public List<GetSegmentsSegments> getSegments() {
     return segments;
   }
 
-  public void setSegments(GetSegmentsSegments segments) {
+  public void setSegments(List<GetSegmentsSegments> segments) {
     this.segments = segments;
   }
 


### PR DESCRIPTION
Update model to match API response....

Proposed fix for [https://github.com/getbrevo/brevo-java/issues/4].

The getSegments now returns correctly with this change.  To test I had to make changes to getSegmentsTest within ContactsApiTest as it was erroring with null limit and offset...As I could not work out how to use API credentials within this test module I added them explicitly to the test.

```
       Long limit = 10l;
        Long offset = 0l;
        String sort = null;
        ApiClient client = new ApiClient();
        client.setApiKey("MY-API-KEY");
        api.setApiClient(client);
       GetSegments response = api.getSegments(limit, offset, sort);
```
