### PR TITLE
N8N-3466 : Update SDK for Loyalty APIs

### DIFF
--- a/docs/BalanceApi.md
+++ b/docs/BalanceApi.md
@@ -672,7 +672,7 @@ Name | Type | Description  | Notes
 
 <a name="getContactBalances"></a>
 # **getContactBalances**
-> ContactBalancesResp getContactBalances(pid)
+> ContactBalancesResp getContactBalances(pid, includeInternal)
 
 Get balance list
 
@@ -703,8 +703,9 @@ partnerKey.setApiKey("YOUR PARTNER KEY");
 
 BalanceApi apiInstance = new BalanceApi();
 UUID pid = new UUID(); // UUID | Loyalty Program Id
+Boolean includeInternal = true; // Boolean | Include Internal
 try {
-    ContactBalancesResp result = apiInstance.getContactBalances(pid);
+    ContactBalancesResp result = apiInstance.getContactBalances(pid, includeInternal);
     System.out.println(result);
 } catch (ApiException e) {
     System.err.println("Exception when calling BalanceApi#getContactBalances");
@@ -717,6 +718,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **pid** | [**UUID**](.md)| Loyalty Program Id |
+ **includeInternal** | **Boolean**| Include Internal | [optional]
 
 ### Return type
 
@@ -733,7 +735,7 @@ Name | Type | Description  | Notes
 
 <a name="getSubscriptionBalances"></a>
 # **getSubscriptionBalances**
-> ModelSubscriptionBalanceResp getSubscriptionBalances(cid, pid)
+> ModelSubscriptionBalanceResp getSubscriptionBalances(cid, pid, includeInternal)
 
 Get subscription balances
 
@@ -765,8 +767,9 @@ partnerKey.setApiKey("YOUR PARTNER KEY");
 BalanceApi apiInstance = new BalanceApi();
 String cid = "cid_example"; // String | Contact Id
 UUID pid = new UUID(); // UUID | Loyalty Program Id
+Boolean includeInternal = true; // Boolean | Include Internal
 try {
-    ModelSubscriptionBalanceResp result = apiInstance.getSubscriptionBalances(cid, pid);
+    ModelSubscriptionBalanceResp result = apiInstance.getSubscriptionBalances(cid, pid, includeInternal);
     System.out.println(result);
 } catch (ApiException e) {
     System.err.println("Exception when calling BalanceApi#getSubscriptionBalances");
@@ -780,6 +783,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **cid** | **String**| Contact Id |
  **pid** | [**UUID**](.md)| Loyalty Program Id |
+ **includeInternal** | **Boolean**| Include Internal | [optional]
 
 ### Return type
 
@@ -796,7 +800,7 @@ Name | Type | Description  | Notes
 
 <a name="loyaltyBalanceProgramsPidActiveBalanceGet"></a>
 # **loyaltyBalanceProgramsPidActiveBalanceGet**
-> BalanceLimit loyaltyBalanceProgramsPidActiveBalanceGet(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort)
+> BalanceLimit loyaltyBalanceProgramsPidActiveBalanceGet(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, includeInternal)
 
 Get Active Balances API
 
@@ -833,8 +837,9 @@ Integer limit = 56; // Integer | Limit
 Integer offset = 56; // Integer | Offset
 String sortField = "sortField_example"; // String | Sort Field
 String sort = "sort_example"; // String | Sort Order
+Boolean includeInternal = true; // Boolean | Include Internal
 try {
-    BalanceLimit result = apiInstance.loyaltyBalanceProgramsPidActiveBalanceGet(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort);
+    BalanceLimit result = apiInstance.loyaltyBalanceProgramsPidActiveBalanceGet(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, includeInternal);
     System.out.println(result);
 } catch (ApiException e) {
     System.err.println("Exception when calling BalanceApi#loyaltyBalanceProgramsPidActiveBalanceGet");
@@ -853,6 +858,7 @@ Name | Type | Description  | Notes
  **offset** | **Integer**| Offset | [optional]
  **sortField** | **String**| Sort Field | [optional]
  **sort** | **String**| Sort Order | [optional]
+ **includeInternal** | **Boolean**| Include Internal | [optional]
 
 ### Return type
 
@@ -997,7 +1003,7 @@ Name | Type | Description  | Notes
 
 <a name="loyaltyBalanceProgramsPidTransactionHistoryGet"></a>
 # **loyaltyBalanceProgramsPidTransactionHistoryGet**
-> TransactionHistoryResp loyaltyBalanceProgramsPidTransactionHistoryGet(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters)
+> TransactionHistoryResp loyaltyBalanceProgramsPidTransactionHistoryGet(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters, status, transactionType)
 
 Get Transaction History API
 
@@ -1035,8 +1041,10 @@ Integer offset = 0; // Integer | Skip a number of records
 String sortField = "createdAt"; // String | Field to sort by
 String sort = "desc"; // String | Sort order, either asc or desc
 List<String> filters = Arrays.asList("filters_example"); // List<String> | Filters to apply
+String status = "status_example"; // String | Filter by transaction status
+String transactionType = "transactionType_example"; // String | Filter by transaction type
 try {
-    TransactionHistoryResp result = apiInstance.loyaltyBalanceProgramsPidTransactionHistoryGet(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters);
+    TransactionHistoryResp result = apiInstance.loyaltyBalanceProgramsPidTransactionHistoryGet(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters, status, transactionType);
     System.out.println(result);
 } catch (ApiException e) {
     System.err.println("Exception when calling BalanceApi#loyaltyBalanceProgramsPidTransactionHistoryGet");
@@ -1056,6 +1064,8 @@ Name | Type | Description  | Notes
  **sortField** | **String**| Field to sort by | [optional] [default to createdAt] [enum: createdAt]
  **sort** | **String**| Sort order, either asc or desc | [optional] [default to desc] [enum: asc, desc]
  **filters** | [**List&lt;String&gt;**](String.md)| Filters to apply | [optional]
+ **status** | **String**| Filter by transaction status | [optional]
+ **transactionType** | **String**| Filter by transaction type | [optional]
 
 ### Return type
 

--- a/docs/CreateBalanceDefinitionPayload.md
+++ b/docs/CreateBalanceDefinitionPayload.md
@@ -16,7 +16,7 @@ Name | Type | Description | Notes
 **maxAmount** | [**BigDecimal**](BigDecimal.md) | Maximum allowable balance amount. |  [optional]
 **maxCreditAmountLimit** | [**BigDecimal**](BigDecimal.md) | Maximum credit allowed per operation. |  [optional]
 **maxDebitAmountLimit** | [**BigDecimal**](BigDecimal.md) | Maximum debit allowed per operation. |  [optional]
-**meta** | **Object** | Additional metadata for the balance definition. |  [optional]
+**meta** | **Map&lt;String, Object&gt;** | Additional metadata for the balance definition. |  [optional]
 **minAmount** | [**BigDecimal**](BigDecimal.md) | Minimum allowable balance amount. |  [optional]
 **name** | **String** | Name of the balance definition. | 
 **unit** | [**UnitEnum**](#UnitEnum) | Unit of balance measurement. | 

--- a/docs/CreateTierGroupRequest.md
+++ b/docs/CreateTierGroupRequest.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **upgradeStrategy** | [**UpgradeStrategyEnum**](#UpgradeStrategyEnum) | Select real_time to upgrade tier on real time balance updates. Select membership_anniversary to upgrade tier on subscription anniversary. Select tier_anniversary to upgrade tier on tier anniversary. |  [optional]
 **downgradeStrategy** | [**DowngradeStrategyEnum**](#DowngradeStrategyEnum) | Select real_time to downgrade tier on real time balance updates. Select membership_anniversary to downgrade tier on subscription anniversary. Select tier_anniversary to downgrade tier on tier anniversary. |  [optional]
 **tierOrder** | **List&lt;String&gt;** | Order of the tiers in the group in ascending order |  [optional]
+**meta** | **Map&lt;String, Object&gt;** | Additional metadata for the tier group |  [optional]
 
 
 <a name="UpgradeStrategyEnum"></a>

--- a/docs/ProgramApi.md
+++ b/docs/ProgramApi.md
@@ -331,7 +331,7 @@ Name | Type | Description  | Notes
 
 <a name="getParameterSubscriptionInfo"></a>
 # **getParameterSubscriptionInfo**
-> SubscriptionHandlerInfo getParameterSubscriptionInfo(pid, contactId, params, loyaltySubscriptionId)
+> SubscriptionHandlerInfo getParameterSubscriptionInfo(pid, contactId, params, loyaltySubscriptionId, includeInternal)
 
 Get Subscription Data
 
@@ -365,8 +365,9 @@ UUID pid = new UUID(); // UUID | Loyalty Program Id
 String contactId = "contactId_example"; // String | Contact Id
 String params = "params_example"; // String | Filter List
 String loyaltySubscriptionId = "loyaltySubscriptionId_example"; // String | Loyalty Subscription Id
+Boolean includeInternal = true; // Boolean | Include Internal
 try {
-    SubscriptionHandlerInfo result = apiInstance.getParameterSubscriptionInfo(pid, contactId, params, loyaltySubscriptionId);
+    SubscriptionHandlerInfo result = apiInstance.getParameterSubscriptionInfo(pid, contactId, params, loyaltySubscriptionId, includeInternal);
     System.out.println(result);
 } catch (ApiException e) {
     System.err.println("Exception when calling ProgramApi#getParameterSubscriptionInfo");
@@ -382,6 +383,7 @@ Name | Type | Description  | Notes
  **contactId** | **String**| Contact Id | [optional]
  **params** | **String**| Filter List | [optional]
  **loyaltySubscriptionId** | **String**| Loyalty Subscription Id | [optional]
+ **includeInternal** | **Boolean**| Include Internal | [optional]
 
 ### Return type
 
@@ -428,8 +430,8 @@ partnerKey.setApiKey("YOUR PARTNER KEY");
 //partner-key.setApiKeyPrefix("Token");
 
 ProgramApi apiInstance = new ProgramApi();
-Object pid = null; // Object | Loyalty Program ID. A unique identifier for the loyalty program.
-Object cid = null; // Object | Contact ID.
+UUID pid = new UUID(); // UUID | Loyalty Program ID. A unique identifier for the loyalty program.
+Integer cid = 56; // Integer | Contact ID.
 try {
     TransactionHistoryResp result = apiInstance.loyaltyConfigProgramsPidContactCidDelete(pid, cid);
     System.out.println(result);
@@ -443,8 +445,8 @@ try {
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **pid** | [**Object**](.md)| Loyalty Program ID. A unique identifier for the loyalty program. |
- **cid** | [**Object**](.md)| Contact ID. |
+ **pid** | [**UUID**](.md)| Loyalty Program ID. A unique identifier for the loyalty program. |
+ **cid** | **Integer**| Contact ID. |
 
 ### Return type
 

--- a/docs/SubscriptionHandlerInfo.md
+++ b/docs/SubscriptionHandlerInfo.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**balance** | **Object** | Balance details for the subscription. |  [optional]
+**balance** | [**SubscriptionBalances**](SubscriptionBalances.md) | Balance details for the subscription. |  [optional]
 **members** | [**List&lt;MemberContact&gt;**](MemberContact.md) | List of members associated with the subscription. |  [optional]
 **reward** | [**List&lt;SubscriptionAttributedReward&gt;**](SubscriptionAttributedReward.md) | List of rewards associated with the subscription. |  [optional]
 **tier** | [**List&lt;SubscriptionTier&gt;**](SubscriptionTier.md) | List of tier assignments for the subscription. |  [optional]

--- a/docs/UpdateBalanceDefinitionPayload.md
+++ b/docs/UpdateBalanceDefinitionPayload.md
@@ -16,7 +16,7 @@ Name | Type | Description | Notes
 **maxAmount** | [**BigDecimal**](BigDecimal.md) | Maximum allowable balance amount. |  [optional]
 **maxCreditAmountLimit** | [**BigDecimal**](BigDecimal.md) | Maximum credit allowed per operation. |  [optional]
 **maxDebitAmountLimit** | [**BigDecimal**](BigDecimal.md) | Maximum debit allowed per operation. |  [optional]
-**meta** | **Object** | Optional metadata for the balance definition. |  [optional]
+**meta** | **Map&lt;String, Object&gt;** | Optional metadata for the balance definition. |  [optional]
 **minAmount** | [**BigDecimal**](BigDecimal.md) | Minimum allowable balance amount. |  [optional]
 **name** | **String** | Name of the balance definition. | 
 **unit** | [**UnitEnum**](#UnitEnum) | Unit of balance measurement. | 

--- a/docs/UpdateTierGroupRequest.md
+++ b/docs/UpdateTierGroupRequest.md
@@ -7,7 +7,8 @@ Name | Type | Description | Notes
 **name** | **String** | Name of the tier group | 
 **tierOrder** | [**List&lt;UUID&gt;**](UUID.md) | Order of the tiers in the group in ascending order | 
 **upgradeStrategy** | [**UpgradeStrategyEnum**](#UpgradeStrategyEnum) | Select real_time to upgrade tier on real time balance updates. Select membership_anniversary to upgrade tier on subscription anniversary. Select tier_anniversary to upgrade tier on tier anniversary. | 
-**downgradeStrategy** | [**DowngradeStrategyEnum**](#DowngradeStrategyEnum) | Select real_time to downgrade tier on real time balance updates. Select membership_anniversary to downgrade tier on subscription anniversary. Select tier_anniversary to downgrade tier on tier anniversary. | 
+**downgradeStrategy** | [**DowngradeStrategyEnum**](#DowngradeStrategyEnum) | Select real_time to downgrade tier on real time balance updates. Select membership_anniversary to downgrade tier on subscription anniversary. Select tier_anniversary to downgrade tier on tier anniversary. |
+**meta** | **Map&lt;String, Object&gt;** | Additional metadata for the tier group |  [optional]
 
 
 <a name="UpgradeStrategyEnum"></a>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.brevo</groupId>
     <artifactId>brevo</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <packaging>jar</packaging>
 
     <name>brevo</name>

--- a/src/main/java/brevoApi/BalanceApi.java
+++ b/src/main/java/brevoApi/BalanceApi.java
@@ -1456,12 +1456,13 @@ public class BalanceApi {
     /**
      * Build call for getContactBalances
      * @param pid Loyalty Program Id (required)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @param progressListener Progress listener
      * @param progressRequestListener Progress request listener
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call getContactBalancesCall(UUID pid, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+    public Call getContactBalancesCall(UUID pid, Boolean includeInternal, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1470,6 +1471,8 @@ public class BalanceApi {
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        if (includeInternal != null)
+        localVarQueryParams.addAll(apiClient.parameterToPair("includeInternal", includeInternal));
 
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 
@@ -1504,15 +1507,15 @@ public class BalanceApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private Call getContactBalancesValidateBeforeCall(UUID pid, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        
+    private Call getContactBalancesValidateBeforeCall(UUID pid, Boolean includeInternal, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+
         // verify the required parameter 'pid' is set
         if (pid == null) {
             throw new ApiException("Missing the required parameter 'pid' when calling getContactBalances(Async)");
         }
-        
 
-        Call call = getContactBalancesCall(pid, progressListener, progressRequestListener);
+
+        Call call = getContactBalancesCall(pid, includeInternal, progressListener, progressRequestListener);
         return call;
 
     }
@@ -1521,11 +1524,12 @@ public class BalanceApi {
      * Get balance list
      * Returns balance list
      * @param pid Loyalty Program Id (required)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @return ContactBalancesResp
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ContactBalancesResp getContactBalances(UUID pid) throws ApiException {
-        ApiResponse<ContactBalancesResp> resp = getContactBalancesWithHttpInfo(pid);
+    public ContactBalancesResp getContactBalances(UUID pid, Boolean includeInternal) throws ApiException {
+        ApiResponse<ContactBalancesResp> resp = getContactBalancesWithHttpInfo(pid, includeInternal);
         return resp.getData();
     }
 
@@ -1533,11 +1537,12 @@ public class BalanceApi {
      * Get balance list
      * Returns balance list
      * @param pid Loyalty Program Id (required)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @return ApiResponse&lt;ContactBalancesResp&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<ContactBalancesResp> getContactBalancesWithHttpInfo(UUID pid) throws ApiException {
-        Call call = getContactBalancesValidateBeforeCall(pid, null, null);
+    public ApiResponse<ContactBalancesResp> getContactBalancesWithHttpInfo(UUID pid, Boolean includeInternal) throws ApiException {
+        Call call = getContactBalancesValidateBeforeCall(pid, includeInternal, null, null);
         Type localVarReturnType = new TypeToken<ContactBalancesResp>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
     }
@@ -1546,11 +1551,12 @@ public class BalanceApi {
      * Get balance list (asynchronously)
      * Returns balance list
      * @param pid Loyalty Program Id (required)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @param callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public Call getContactBalancesAsync(UUID pid, final ApiCallback<ContactBalancesResp> callback) throws ApiException {
+    public Call getContactBalancesAsync(UUID pid, Boolean includeInternal, final ApiCallback<ContactBalancesResp> callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;
         ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
@@ -1571,7 +1577,7 @@ public class BalanceApi {
             };
         }
 
-        Call call = getContactBalancesValidateBeforeCall(pid, progressListener, progressRequestListener);
+        Call call = getContactBalancesValidateBeforeCall(pid, includeInternal, progressListener, progressRequestListener);
         Type localVarReturnType = new TypeToken<ContactBalancesResp>(){}.getType();
         apiClient.executeAsync(call, localVarReturnType, callback);
         return call;
@@ -1580,12 +1586,13 @@ public class BalanceApi {
      * Build call for getSubscriptionBalances
      * @param cid Contact Id (required)
      * @param pid Loyalty Program Id (required)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @param progressListener Progress listener
      * @param progressRequestListener Progress request listener
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call getSubscriptionBalancesCall(String cid, UUID pid, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+    public Call getSubscriptionBalancesCall(String cid, UUID pid, Boolean includeInternal, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1595,6 +1602,8 @@ public class BalanceApi {
 
         List<Pair> localVarQueryParams = new ArrayList<Pair>();
         List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        if (includeInternal != null)
+        localVarQueryParams.addAll(apiClient.parameterToPair("includeInternal", includeInternal));
 
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 
@@ -1629,20 +1638,20 @@ public class BalanceApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private Call getSubscriptionBalancesValidateBeforeCall(String cid, UUID pid, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        
+    private Call getSubscriptionBalancesValidateBeforeCall(String cid, UUID pid, Boolean includeInternal, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+
         // verify the required parameter 'cid' is set
         if (cid == null) {
             throw new ApiException("Missing the required parameter 'cid' when calling getSubscriptionBalances(Async)");
         }
-        
+
         // verify the required parameter 'pid' is set
         if (pid == null) {
             throw new ApiException("Missing the required parameter 'pid' when calling getSubscriptionBalances(Async)");
         }
-        
 
-        Call call = getSubscriptionBalancesCall(cid, pid, progressListener, progressRequestListener);
+
+        Call call = getSubscriptionBalancesCall(cid, pid, includeInternal, progressListener, progressRequestListener);
         return call;
 
     }
@@ -1652,11 +1661,12 @@ public class BalanceApi {
      * Returns subscription balances
      * @param cid Contact Id (required)
      * @param pid Loyalty Program Id (required)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @return ModelSubscriptionBalanceResp
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ModelSubscriptionBalanceResp getSubscriptionBalances(String cid, UUID pid) throws ApiException {
-        ApiResponse<ModelSubscriptionBalanceResp> resp = getSubscriptionBalancesWithHttpInfo(cid, pid);
+    public ModelSubscriptionBalanceResp getSubscriptionBalances(String cid, UUID pid, Boolean includeInternal) throws ApiException {
+        ApiResponse<ModelSubscriptionBalanceResp> resp = getSubscriptionBalancesWithHttpInfo(cid, pid, includeInternal);
         return resp.getData();
     }
 
@@ -1665,11 +1675,12 @@ public class BalanceApi {
      * Returns subscription balances
      * @param cid Contact Id (required)
      * @param pid Loyalty Program Id (required)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @return ApiResponse&lt;ModelSubscriptionBalanceResp&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<ModelSubscriptionBalanceResp> getSubscriptionBalancesWithHttpInfo(String cid, UUID pid) throws ApiException {
-        Call call = getSubscriptionBalancesValidateBeforeCall(cid, pid, null, null);
+    public ApiResponse<ModelSubscriptionBalanceResp> getSubscriptionBalancesWithHttpInfo(String cid, UUID pid, Boolean includeInternal) throws ApiException {
+        Call call = getSubscriptionBalancesValidateBeforeCall(cid, pid, includeInternal, null, null);
         Type localVarReturnType = new TypeToken<ModelSubscriptionBalanceResp>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
     }
@@ -1679,11 +1690,12 @@ public class BalanceApi {
      * Returns subscription balances
      * @param cid Contact Id (required)
      * @param pid Loyalty Program Id (required)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @param callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public Call getSubscriptionBalancesAsync(String cid, UUID pid, final ApiCallback<ModelSubscriptionBalanceResp> callback) throws ApiException {
+    public Call getSubscriptionBalancesAsync(String cid, UUID pid, Boolean includeInternal, final ApiCallback<ModelSubscriptionBalanceResp> callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;
         ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
@@ -1704,7 +1716,7 @@ public class BalanceApi {
             };
         }
 
-        Call call = getSubscriptionBalancesValidateBeforeCall(cid, pid, progressListener, progressRequestListener);
+        Call call = getSubscriptionBalancesValidateBeforeCall(cid, pid, includeInternal, progressListener, progressRequestListener);
         Type localVarReturnType = new TypeToken<ModelSubscriptionBalanceResp>(){}.getType();
         apiClient.executeAsync(call, localVarReturnType, callback);
         return call;
@@ -1718,12 +1730,13 @@ public class BalanceApi {
      * @param offset Offset (optional)
      * @param sortField Sort Field (optional)
      * @param sort Sort Order (optional)
+     * @param includeInternal Include Internal (optional)
      * @param progressListener Progress listener
      * @param progressRequestListener Progress request listener
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call loyaltyBalanceProgramsPidActiveBalanceGetCall(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+    public Call loyaltyBalanceProgramsPidActiveBalanceGetCall(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, Boolean includeInternal, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -1744,6 +1757,8 @@ public class BalanceApi {
         localVarQueryParams.addAll(apiClient.parameterToPair("contact_id", contactId));
         if (balanceDefinitionId != null)
         localVarQueryParams.addAll(apiClient.parameterToPair("balance_definition_id", balanceDefinitionId));
+        if (includeInternal != null)
+        localVarQueryParams.addAll(apiClient.parameterToPair("includeInternal", includeInternal));
 
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 
@@ -1778,7 +1793,7 @@ public class BalanceApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private Call loyaltyBalanceProgramsPidActiveBalanceGetValidateBeforeCall(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+    private Call loyaltyBalanceProgramsPidActiveBalanceGetValidateBeforeCall(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, Boolean includeInternal, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         
         // verify the required parameter 'pid' is set
         if (pid == null) {
@@ -1796,7 +1811,7 @@ public class BalanceApi {
         }
         
 
-        Call call = loyaltyBalanceProgramsPidActiveBalanceGetCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, progressListener, progressRequestListener);
+        Call call = loyaltyBalanceProgramsPidActiveBalanceGetCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, includeInternal, progressListener, progressRequestListener);
         return call;
 
     }
@@ -1811,11 +1826,12 @@ public class BalanceApi {
      * @param offset Offset (optional)
      * @param sortField Sort Field (optional)
      * @param sort Sort Order (optional)
+     * @param includeInternal Include Internal (optional)
      * @return BalanceLimit
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public BalanceLimit loyaltyBalanceProgramsPidActiveBalanceGet(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort) throws ApiException {
-        ApiResponse<BalanceLimit> resp = loyaltyBalanceProgramsPidActiveBalanceGetWithHttpInfo(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort);
+    public BalanceLimit loyaltyBalanceProgramsPidActiveBalanceGet(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, Boolean includeInternal) throws ApiException {
+        ApiResponse<BalanceLimit> resp = loyaltyBalanceProgramsPidActiveBalanceGetWithHttpInfo(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, includeInternal);
         return resp.getData();
     }
 
@@ -1829,11 +1845,12 @@ public class BalanceApi {
      * @param offset Offset (optional)
      * @param sortField Sort Field (optional)
      * @param sort Sort Order (optional)
+     * @param includeInternal Include Internal (optional)
      * @return ApiResponse&lt;BalanceLimit&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<BalanceLimit> loyaltyBalanceProgramsPidActiveBalanceGetWithHttpInfo(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort) throws ApiException {
-        Call call = loyaltyBalanceProgramsPidActiveBalanceGetValidateBeforeCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, null, null);
+    public ApiResponse<BalanceLimit> loyaltyBalanceProgramsPidActiveBalanceGetWithHttpInfo(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, Boolean includeInternal) throws ApiException {
+        Call call = loyaltyBalanceProgramsPidActiveBalanceGetValidateBeforeCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, includeInternal, null, null);
         Type localVarReturnType = new TypeToken<BalanceLimit>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
     }
@@ -1848,11 +1865,12 @@ public class BalanceApi {
      * @param offset Offset (optional)
      * @param sortField Sort Field (optional)
      * @param sort Sort Order (optional)
+     * @param includeInternal Include Internal (optional)
      * @param callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public Call loyaltyBalanceProgramsPidActiveBalanceGetAsync(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, final ApiCallback<BalanceLimit> callback) throws ApiException {
+    public Call loyaltyBalanceProgramsPidActiveBalanceGetAsync(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, Boolean includeInternal, final ApiCallback<BalanceLimit> callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;
         ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
@@ -1873,7 +1891,7 @@ public class BalanceApi {
             };
         }
 
-        Call call = loyaltyBalanceProgramsPidActiveBalanceGetValidateBeforeCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, progressListener, progressRequestListener);
+        Call call = loyaltyBalanceProgramsPidActiveBalanceGetValidateBeforeCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, includeInternal, progressListener, progressRequestListener);
         Type localVarReturnType = new TypeToken<BalanceLimit>(){}.getType();
         apiClient.executeAsync(call, localVarReturnType, callback);
         return call;
@@ -2162,12 +2180,14 @@ public class BalanceApi {
      * @param sortField Field to sort by (optional, default to createdAt)
      * @param sort Sort order, either asc or desc (optional, default to desc)
      * @param filters Filters to apply (optional)
+     * @param status Transaction status filter (optional)
+     * @param transactionType Transaction type filter (optional)
      * @param progressListener Progress listener
      * @param progressRequestListener Progress request listener
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call loyaltyBalanceProgramsPidTransactionHistoryGetCall(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, List<String> filters, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+    public Call loyaltyBalanceProgramsPidTransactionHistoryGetCall(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, List<String> filters, String status, String transactionType, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -2190,6 +2210,10 @@ public class BalanceApi {
         localVarQueryParams.addAll(apiClient.parameterToPair("balanceDefinitionId", balanceDefinitionId));
         if (filters != null)
         localVarCollectionQueryParams.addAll(apiClient.parameterToPairs("multi", "filters", filters));
+        if (status != null)
+        localVarQueryParams.addAll(apiClient.parameterToPair("status", status));
+        if (transactionType != null)
+        localVarQueryParams.addAll(apiClient.parameterToPair("transactionType", transactionType));
 
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 
@@ -2224,25 +2248,25 @@ public class BalanceApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private Call loyaltyBalanceProgramsPidTransactionHistoryGetValidateBeforeCall(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, List<String> filters, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        
+    private Call loyaltyBalanceProgramsPidTransactionHistoryGetValidateBeforeCall(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, List<String> filters, String status, String transactionType, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+
         // verify the required parameter 'pid' is set
         if (pid == null) {
             throw new ApiException("Missing the required parameter 'pid' when calling loyaltyBalanceProgramsPidTransactionHistoryGet(Async)");
         }
-        
+
         // verify the required parameter 'contactId' is set
         if (contactId == null) {
             throw new ApiException("Missing the required parameter 'contactId' when calling loyaltyBalanceProgramsPidTransactionHistoryGet(Async)");
         }
-        
+
         // verify the required parameter 'balanceDefinitionId' is set
         if (balanceDefinitionId == null) {
             throw new ApiException("Missing the required parameter 'balanceDefinitionId' when calling loyaltyBalanceProgramsPidTransactionHistoryGet(Async)");
         }
-        
 
-        Call call = loyaltyBalanceProgramsPidTransactionHistoryGetCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters, progressListener, progressRequestListener);
+
+        Call call = loyaltyBalanceProgramsPidTransactionHistoryGetCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters, status, transactionType, progressListener, progressRequestListener);
         return call;
 
     }
@@ -2258,11 +2282,13 @@ public class BalanceApi {
      * @param sortField Field to sort by (optional, default to createdAt)
      * @param sort Sort order, either asc or desc (optional, default to desc)
      * @param filters Filters to apply (optional)
+     * @param status Transaction status filter: draft, completed, rejected, cancelled, expired (optional)
+     * @param transactionType Transaction type filter: credit, debit (optional)
      * @return TransactionHistoryResp
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public TransactionHistoryResp loyaltyBalanceProgramsPidTransactionHistoryGet(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, List<String> filters) throws ApiException {
-        ApiResponse<TransactionHistoryResp> resp = loyaltyBalanceProgramsPidTransactionHistoryGetWithHttpInfo(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters);
+    public TransactionHistoryResp loyaltyBalanceProgramsPidTransactionHistoryGet(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, List<String> filters, String status, String transactionType) throws ApiException {
+        ApiResponse<TransactionHistoryResp> resp = loyaltyBalanceProgramsPidTransactionHistoryGetWithHttpInfo(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters, status, transactionType);
         return resp.getData();
     }
 
@@ -2277,11 +2303,13 @@ public class BalanceApi {
      * @param sortField Field to sort by (optional, default to createdAt)
      * @param sort Sort order, either asc or desc (optional, default to desc)
      * @param filters Filters to apply (optional)
+     * @param status Transaction status filter: draft, completed, rejected, cancelled, expired (optional)
+     * @param transactionType Transaction type filter: credit, debit (optional)
      * @return ApiResponse&lt;TransactionHistoryResp&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<TransactionHistoryResp> loyaltyBalanceProgramsPidTransactionHistoryGetWithHttpInfo(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, List<String> filters) throws ApiException {
-        Call call = loyaltyBalanceProgramsPidTransactionHistoryGetValidateBeforeCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters, null, null);
+    public ApiResponse<TransactionHistoryResp> loyaltyBalanceProgramsPidTransactionHistoryGetWithHttpInfo(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, List<String> filters, String status, String transactionType) throws ApiException {
+        Call call = loyaltyBalanceProgramsPidTransactionHistoryGetValidateBeforeCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters, status, transactionType, null, null);
         Type localVarReturnType = new TypeToken<TransactionHistoryResp>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
     }
@@ -2297,11 +2325,13 @@ public class BalanceApi {
      * @param sortField Field to sort by (optional, default to createdAt)
      * @param sort Sort order, either asc or desc (optional, default to desc)
      * @param filters Filters to apply (optional)
+     * @param status Transaction status filter: draft, completed, rejected, cancelled, expired (optional)
+     * @param transactionType Transaction type filter: credit, debit (optional)
      * @param callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public Call loyaltyBalanceProgramsPidTransactionHistoryGetAsync(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, List<String> filters, final ApiCallback<TransactionHistoryResp> callback) throws ApiException {
+    public Call loyaltyBalanceProgramsPidTransactionHistoryGetAsync(UUID pid, Integer contactId, UUID balanceDefinitionId, Integer limit, Integer offset, String sortField, String sort, List<String> filters, String status, String transactionType, final ApiCallback<TransactionHistoryResp> callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;
         ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
@@ -2322,7 +2352,7 @@ public class BalanceApi {
             };
         }
 
-        Call call = loyaltyBalanceProgramsPidTransactionHistoryGetValidateBeforeCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters, progressListener, progressRequestListener);
+        Call call = loyaltyBalanceProgramsPidTransactionHistoryGetValidateBeforeCall(pid, contactId, balanceDefinitionId, limit, offset, sortField, sort, filters, status, transactionType, progressListener, progressRequestListener);
         Type localVarReturnType = new TypeToken<TransactionHistoryResp>(){}.getType();
         apiClient.executeAsync(call, localVarReturnType, callback);
         return call;

--- a/src/main/java/brevoApi/ProgramApi.java
+++ b/src/main/java/brevoApi/ProgramApi.java
@@ -694,12 +694,13 @@ public class ProgramApi {
      * @param contactId Contact Id (optional)
      * @param params Filter List (optional)
      * @param loyaltySubscriptionId Loyalty Subscription Id (optional)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @param progressListener Progress listener
      * @param progressRequestListener Progress request listener
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call getParameterSubscriptionInfoCall(UUID pid, String contactId, String params, String loyaltySubscriptionId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+    public Call getParameterSubscriptionInfoCall(UUID pid, String contactId, String params, String loyaltySubscriptionId, Boolean includeInternal, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -714,6 +715,8 @@ public class ProgramApi {
         localVarQueryParams.addAll(apiClient.parameterToPair("params", params));
         if (loyaltySubscriptionId != null)
         localVarQueryParams.addAll(apiClient.parameterToPair("loyaltySubscriptionId", loyaltySubscriptionId));
+        if (includeInternal != null)
+        localVarQueryParams.addAll(apiClient.parameterToPair("includeInternal", includeInternal));
 
         Map<String, String> localVarHeaderParams = new HashMap<String, String>();
 
@@ -748,15 +751,15 @@ public class ProgramApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private Call getParameterSubscriptionInfoValidateBeforeCall(UUID pid, String contactId, String params, String loyaltySubscriptionId, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        
+    private Call getParameterSubscriptionInfoValidateBeforeCall(UUID pid, String contactId, String params, String loyaltySubscriptionId, Boolean includeInternal, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+
         // verify the required parameter 'pid' is set
         if (pid == null) {
             throw new ApiException("Missing the required parameter 'pid' when calling getParameterSubscriptionInfo(Async)");
         }
-        
 
-        Call call = getParameterSubscriptionInfoCall(pid, contactId, params, loyaltySubscriptionId, progressListener, progressRequestListener);
+
+        Call call = getParameterSubscriptionInfoCall(pid, contactId, params, loyaltySubscriptionId, includeInternal, progressListener, progressRequestListener);
         return call;
 
     }
@@ -768,11 +771,12 @@ public class ProgramApi {
      * @param contactId Contact Id (optional)
      * @param params Filter List (optional)
      * @param loyaltySubscriptionId Loyalty Subscription Id (optional)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @return SubscriptionHandlerInfo
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public SubscriptionHandlerInfo getParameterSubscriptionInfo(UUID pid, String contactId, String params, String loyaltySubscriptionId) throws ApiException {
-        ApiResponse<SubscriptionHandlerInfo> resp = getParameterSubscriptionInfoWithHttpInfo(pid, contactId, params, loyaltySubscriptionId);
+    public SubscriptionHandlerInfo getParameterSubscriptionInfo(UUID pid, String contactId, String params, String loyaltySubscriptionId, Boolean includeInternal) throws ApiException {
+        ApiResponse<SubscriptionHandlerInfo> resp = getParameterSubscriptionInfoWithHttpInfo(pid, contactId, params, loyaltySubscriptionId, includeInternal);
         return resp.getData();
     }
 
@@ -783,11 +787,12 @@ public class ProgramApi {
      * @param contactId Contact Id (optional)
      * @param params Filter List (optional)
      * @param loyaltySubscriptionId Loyalty Subscription Id (optional)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @return ApiResponse&lt;SubscriptionHandlerInfo&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<SubscriptionHandlerInfo> getParameterSubscriptionInfoWithHttpInfo(UUID pid, String contactId, String params, String loyaltySubscriptionId) throws ApiException {
-        Call call = getParameterSubscriptionInfoValidateBeforeCall(pid, contactId, params, loyaltySubscriptionId, null, null);
+    public ApiResponse<SubscriptionHandlerInfo> getParameterSubscriptionInfoWithHttpInfo(UUID pid, String contactId, String params, String loyaltySubscriptionId, Boolean includeInternal) throws ApiException {
+        Call call = getParameterSubscriptionInfoValidateBeforeCall(pid, contactId, params, loyaltySubscriptionId, includeInternal, null, null);
         Type localVarReturnType = new TypeToken<SubscriptionHandlerInfo>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
     }
@@ -799,11 +804,12 @@ public class ProgramApi {
      * @param contactId Contact Id (optional)
      * @param params Filter List (optional)
      * @param loyaltySubscriptionId Loyalty Subscription Id (optional)
+     * @param includeInternal Include balances tied to internal definitions. (optional)
      * @param callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public Call getParameterSubscriptionInfoAsync(UUID pid, String contactId, String params, String loyaltySubscriptionId, final ApiCallback<SubscriptionHandlerInfo> callback) throws ApiException {
+    public Call getParameterSubscriptionInfoAsync(UUID pid, String contactId, String params, String loyaltySubscriptionId, Boolean includeInternal, final ApiCallback<SubscriptionHandlerInfo> callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;
         ProgressRequestBody.ProgressRequestListener progressRequestListener = null;
@@ -824,7 +830,7 @@ public class ProgramApi {
             };
         }
 
-        Call call = getParameterSubscriptionInfoValidateBeforeCall(pid, contactId, params, loyaltySubscriptionId, progressListener, progressRequestListener);
+        Call call = getParameterSubscriptionInfoValidateBeforeCall(pid, contactId, params, loyaltySubscriptionId, includeInternal, progressListener, progressRequestListener);
         Type localVarReturnType = new TypeToken<SubscriptionHandlerInfo>(){}.getType();
         apiClient.executeAsync(call, localVarReturnType, callback);
         return call;
@@ -838,7 +844,7 @@ public class ProgramApi {
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
      */
-    public Call loyaltyConfigProgramsPidContactCidDeleteCall(Object pid, Object cid, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+    public Call loyaltyConfigProgramsPidContactCidDeleteCall(UUID pid, Integer cid, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -882,18 +888,17 @@ public class ProgramApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private Call loyaltyConfigProgramsPidContactCidDeleteValidateBeforeCall(Object pid, Object cid, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
-        
+    private Call loyaltyConfigProgramsPidContactCidDeleteValidateBeforeCall(UUID pid, Integer cid, final ProgressResponseBody.ProgressListener progressListener, final ProgressRequestBody.ProgressRequestListener progressRequestListener) throws ApiException {
+
         // verify the required parameter 'pid' is set
         if (pid == null) {
             throw new ApiException("Missing the required parameter 'pid' when calling loyaltyConfigProgramsPidContactCidDelete(Async)");
         }
-        
+
         // verify the required parameter 'cid' is set
         if (cid == null) {
             throw new ApiException("Missing the required parameter 'cid' when calling loyaltyConfigProgramsPidContactCidDelete(Async)");
         }
-        
 
         Call call = loyaltyConfigProgramsPidContactCidDeleteCall(pid, cid, progressListener, progressRequestListener);
         return call;
@@ -908,7 +913,7 @@ public class ProgramApi {
      * @return TransactionHistoryResp
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public TransactionHistoryResp loyaltyConfigProgramsPidContactCidDelete(Object pid, Object cid) throws ApiException {
+    public TransactionHistoryResp loyaltyConfigProgramsPidContactCidDelete(UUID pid, Integer cid) throws ApiException {
         ApiResponse<TransactionHistoryResp> resp = loyaltyConfigProgramsPidContactCidDeleteWithHttpInfo(pid, cid);
         return resp.getData();
     }
@@ -921,7 +926,7 @@ public class ProgramApi {
      * @return ApiResponse&lt;TransactionHistoryResp&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      */
-    public ApiResponse<TransactionHistoryResp> loyaltyConfigProgramsPidContactCidDeleteWithHttpInfo(Object pid, Object cid) throws ApiException {
+    public ApiResponse<TransactionHistoryResp> loyaltyConfigProgramsPidContactCidDeleteWithHttpInfo(UUID pid, Integer cid) throws ApiException {
         Call call = loyaltyConfigProgramsPidContactCidDeleteValidateBeforeCall(pid, cid, null, null);
         Type localVarReturnType = new TypeToken<TransactionHistoryResp>(){}.getType();
         return apiClient.execute(call, localVarReturnType);
@@ -936,7 +941,7 @@ public class ProgramApi {
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
      */
-    public Call loyaltyConfigProgramsPidContactCidDeleteAsync(Object pid, Object cid, final ApiCallback<TransactionHistoryResp> callback) throws ApiException {
+    public Call loyaltyConfigProgramsPidContactCidDeleteAsync(UUID pid, Integer cid, final ApiCallback<TransactionHistoryResp> callback) throws ApiException {
 
         ProgressResponseBody.ProgressListener progressListener = null;
         ProgressRequestBody.ProgressRequestListener progressRequestListener = null;

--- a/src/main/java/brevoModel/CreateBalanceDefinitionPayload.java
+++ b/src/main/java/brevoModel/CreateBalanceDefinitionPayload.java
@@ -23,6 +23,8 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
 import org.threeten.bp.LocalDate;
 
 /**
@@ -313,7 +315,7 @@ public class CreateBalanceDefinitionPayload {
   private BigDecimal maxDebitAmountLimit = null;
 
   @SerializedName("meta")
-  private Object meta = null;
+  private Map<String, Object> meta = null;
 
   @SerializedName("minAmount")
   private BigDecimal minAmount = null;
@@ -617,8 +619,16 @@ public class CreateBalanceDefinitionPayload {
     this.maxDebitAmountLimit = maxDebitAmountLimit;
   }
 
-  public CreateBalanceDefinitionPayload meta(Object meta) {
+  public CreateBalanceDefinitionPayload meta(Map<String, Object> meta) {
     this.meta = meta;
+    return this;
+  }
+
+  public CreateBalanceDefinitionPayload putMetaItem(String key, Object metaItem) {
+    if (this.meta == null) {
+      this.meta = new HashMap<String, Object>();
+    }
+    this.meta.put(key, metaItem);
     return this;
   }
 
@@ -627,11 +637,11 @@ public class CreateBalanceDefinitionPayload {
    * @return meta
   **/
   @ApiModelProperty(value = "Additional metadata for the balance definition.")
-  public Object getMeta() {
+  public Map<String, Object> getMeta() {
     return meta;
   }
 
-  public void setMeta(Object meta) {
+  public void setMeta(Map<String, Object> meta) {
     this.meta = meta;
   }
 

--- a/src/main/java/brevoModel/CreateTierGroupRequest.java
+++ b/src/main/java/brevoModel/CreateTierGroupRequest.java
@@ -23,7 +23,9 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * CreateTierGroupRequest
@@ -140,6 +142,9 @@ public class CreateTierGroupRequest {
   @SerializedName("tierOrder")
   private List<String> tierOrder = null;
 
+  @SerializedName("meta")
+  private Map<String, Object> meta = null;
+
   public CreateTierGroupRequest name(String name) {
     this.name = name;
     return this;
@@ -220,6 +225,32 @@ public class CreateTierGroupRequest {
     this.tierOrder = tierOrder;
   }
 
+  public CreateTierGroupRequest meta(Map<String, Object> meta) {
+    this.meta = meta;
+    return this;
+  }
+
+  public CreateTierGroupRequest putMetaItem(String key, Object metaItem) {
+    if (this.meta == null) {
+      this.meta = new HashMap<String, Object>();
+    }
+    this.meta.put(key, metaItem);
+    return this;
+  }
+
+   /**
+   * Additional metadata for the tier group
+   * @return meta
+  **/
+  @ApiModelProperty(value = "Additional metadata for the tier group")
+  public Map<String, Object> getMeta() {
+    return meta;
+  }
+
+  public void setMeta(Map<String, Object> meta) {
+    this.meta = meta;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -233,12 +264,13 @@ public class CreateTierGroupRequest {
     return ObjectUtils.equals(this.name, createTierGroupRequest.name) &&
     ObjectUtils.equals(this.upgradeStrategy, createTierGroupRequest.upgradeStrategy) &&
     ObjectUtils.equals(this.downgradeStrategy, createTierGroupRequest.downgradeStrategy) &&
-    ObjectUtils.equals(this.tierOrder, createTierGroupRequest.tierOrder);
+    ObjectUtils.equals(this.tierOrder, createTierGroupRequest.tierOrder) &&
+    ObjectUtils.equals(this.meta, createTierGroupRequest.meta);
   }
 
   @Override
   public int hashCode() {
-    return ObjectUtils.hashCodeMulti(name, upgradeStrategy, downgradeStrategy, tierOrder);
+    return ObjectUtils.hashCodeMulti(name, upgradeStrategy, downgradeStrategy, tierOrder, meta);
   }
 
 
@@ -246,11 +278,12 @@ public class CreateTierGroupRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class CreateTierGroupRequest {\n");
-    
+
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    upgradeStrategy: ").append(toIndentedString(upgradeStrategy)).append("\n");
     sb.append("    downgradeStrategy: ").append(toIndentedString(downgradeStrategy)).append("\n");
     sb.append("    tierOrder: ").append(toIndentedString(tierOrder)).append("\n");
+    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/brevoModel/SubscriptionHandlerInfo.java
+++ b/src/main/java/brevoModel/SubscriptionHandlerInfo.java
@@ -16,6 +16,7 @@ package brevoModel;
 import org.apache.commons.lang3.ObjectUtils;
 import brevoModel.MemberContact;
 import brevoModel.SubscriptionAttributedReward;
+import brevoModel.SubscriptionBalances;
 import brevoModel.SubscriptionTier;
 import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
@@ -34,7 +35,7 @@ import java.util.List;
 @javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2025-12-22T15:36:05.341+05:30")
 public class SubscriptionHandlerInfo {
   @SerializedName("balance")
-  private Object balance = null;
+  private SubscriptionBalances balance = null;
 
   @SerializedName("members")
   private List<MemberContact> members = null;
@@ -45,7 +46,7 @@ public class SubscriptionHandlerInfo {
   @SerializedName("tier")
   private List<SubscriptionTier> tier = null;
 
-  public SubscriptionHandlerInfo balance(Object balance) {
+  public SubscriptionHandlerInfo balance(SubscriptionBalances balance) {
     this.balance = balance;
     return this;
   }
@@ -55,11 +56,11 @@ public class SubscriptionHandlerInfo {
    * @return balance
   **/
   @ApiModelProperty(value = "Balance details for the subscription.")
-  public Object getBalance() {
+  public SubscriptionBalances getBalance() {
     return balance;
   }
 
-  public void setBalance(Object balance) {
+  public void setBalance(SubscriptionBalances balance) {
     this.balance = balance;
   }
 

--- a/src/main/java/brevoModel/UpdateBalanceDefinitionPayload.java
+++ b/src/main/java/brevoModel/UpdateBalanceDefinitionPayload.java
@@ -23,6 +23,8 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Payload for updating an existing balance definition, including expiry rules, rounding strategies, and constraints.
@@ -312,7 +314,7 @@ public class UpdateBalanceDefinitionPayload {
   private BigDecimal maxDebitAmountLimit = null;
 
   @SerializedName("meta")
-  private Object meta = null;
+  private Map<String, Object> meta = null;
 
   @SerializedName("minAmount")
   private BigDecimal minAmount = null;
@@ -616,8 +618,16 @@ public class UpdateBalanceDefinitionPayload {
     this.maxDebitAmountLimit = maxDebitAmountLimit;
   }
 
-  public UpdateBalanceDefinitionPayload meta(Object meta) {
+  public UpdateBalanceDefinitionPayload meta(Map<String, Object> meta) {
     this.meta = meta;
+    return this;
+  }
+
+  public UpdateBalanceDefinitionPayload putMetaItem(String key, Object metaItem) {
+    if (this.meta == null) {
+      this.meta = new HashMap<String, Object>();
+    }
+    this.meta.put(key, metaItem);
     return this;
   }
 
@@ -626,11 +636,11 @@ public class UpdateBalanceDefinitionPayload {
    * @return meta
   **/
   @ApiModelProperty(value = "Optional metadata for the balance definition.")
-  public Object getMeta() {
+  public Map<String, Object> getMeta() {
     return meta;
   }
 
-  public void setMeta(Object meta) {
+  public void setMeta(Map<String, Object> meta) {
     this.meta = meta;
   }
 

--- a/src/main/java/brevoModel/UpdateTierGroupRequest.java
+++ b/src/main/java/brevoModel/UpdateTierGroupRequest.java
@@ -23,7 +23,9 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -141,6 +143,9 @@ public class UpdateTierGroupRequest {
   @SerializedName("downgradeStrategy")
   private DowngradeStrategyEnum downgradeStrategy = DowngradeStrategyEnum.REAL_TIME;
 
+  @SerializedName("meta")
+  private Map<String, Object> meta = null;
+
   public UpdateTierGroupRequest name(String name) {
     this.name = name;
     return this;
@@ -218,6 +223,32 @@ public class UpdateTierGroupRequest {
     this.downgradeStrategy = downgradeStrategy;
   }
 
+  public UpdateTierGroupRequest meta(Map<String, Object> meta) {
+    this.meta = meta;
+    return this;
+  }
+
+  public UpdateTierGroupRequest putMetaItem(String key, Object metaItem) {
+    if (this.meta == null) {
+      this.meta = new HashMap<String, Object>();
+    }
+    this.meta.put(key, metaItem);
+    return this;
+  }
+
+   /**
+   * Additional metadata for the tier group
+   * @return meta
+  **/
+  @ApiModelProperty(value = "Additional metadata for the tier group")
+  public Map<String, Object> getMeta() {
+    return meta;
+  }
+
+  public void setMeta(Map<String, Object> meta) {
+    this.meta = meta;
+  }
+
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -231,12 +262,13 @@ public class UpdateTierGroupRequest {
     return ObjectUtils.equals(this.name, updateTierGroupRequest.name) &&
     ObjectUtils.equals(this.tierOrder, updateTierGroupRequest.tierOrder) &&
     ObjectUtils.equals(this.upgradeStrategy, updateTierGroupRequest.upgradeStrategy) &&
-    ObjectUtils.equals(this.downgradeStrategy, updateTierGroupRequest.downgradeStrategy);
+    ObjectUtils.equals(this.downgradeStrategy, updateTierGroupRequest.downgradeStrategy) &&
+    ObjectUtils.equals(this.meta, updateTierGroupRequest.meta);
   }
 
   @Override
   public int hashCode() {
-    return ObjectUtils.hashCodeMulti(name, tierOrder, upgradeStrategy, downgradeStrategy);
+    return ObjectUtils.hashCodeMulti(name, tierOrder, upgradeStrategy, downgradeStrategy, meta);
   }
 
 
@@ -244,11 +276,12 @@ public class UpdateTierGroupRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class UpdateTierGroupRequest {\n");
-    
+
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    tierOrder: ").append(toIndentedString(tierOrder)).append("\n");
     sb.append("    upgradeStrategy: ").append(toIndentedString(upgradeStrategy)).append("\n");
     sb.append("    downgradeStrategy: ").append(toIndentedString(downgradeStrategy)).append("\n");
+    sb.append("    meta: ").append(toIndentedString(meta)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
Summary                                                                                                                                                              
   
  Version Bump                                                                                                                                                         
                  
  - pom.xml: 1.1.2 → 1.1.3                                                                                                                                             
   
  BalanceApi — New includeInternal parameter                                                                                                                           
                  
  Added an optional Boolean includeInternal query parameter to two endpoints:                                                                                          
  - getContactBalances(UUID pid, Boolean includeInternal) — filters balances tied to internal definitions
  - getSubscriptionBalances(String cid, UUID pid, Boolean includeInternal) — same filter for subscription-level balances                                               
                                                                                                                        
  All sync, async, and WithHttpInfo variants were updated accordingly.                                                                                                 
                                                                                                                                                                       
  ProgramApi — New includeInternal parameter + type fixes                                                                                                              
                                                                                                                                                                       
  - getParameterSubscriptionInfo(...) — added Boolean includeInternal optional query param (all variants updated)                                                      
  - loyaltyConfigProgramsPidContactCidDelete(...) — parameter types tightened: Object pid → UUID pid, Object cid → Integer cid
                                                                                                                                                                       
 