### PR TITLE
feat: SMS-2500_1 | Add support of params in send transactional sms API

### DIFF
--- a/docs/SendTransacSms.md
+++ b/docs/SendTransacSms.md
@@ -5,14 +5,15 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **organisationPrefix** | **String** | A recognizable prefix will ensure your audience knows who you are. Recommended by U.S. carriers. This will be added as your Brand Name before the message content. **Prefer verifying maximum length of 160 characters including this prefix in message content to avoid multiple sending of same sms.** |  [optional]
-**recipient** | **String** | Mobile number to send SMS with the country code | 
-**sender** | **String** | Name of the sender. **The number of characters is limited to 11 for alphanumeric characters and 15 for numeric characters**  | 
-**tag** | **String** | Tag of the message. Can be a string or an array of strings (e.g., &quot;accountValidation&quot; or [&quot;tag1&quot;, &quot;tag2&quot;]). |  [optional]
+**recipient** | **String** | Mobile number to send SMS with the country code |
+**sender** | **String** | Name of the sender. **The number of characters is limited to 11 for alphanumeric characters and 15 for numeric characters**  |
+**tag** | [**SendTransacSmsTag**](SendTransacSmsTag.md) | Tag of the message |  [optional]
 **type** | [**TypeEnum**](#TypeEnum) | Type of the SMS. Marketing SMS messages are those sent typically with marketing content. Transactional SMS messages are sent to individuals and are triggered in response to some action, such as a sign-up, purchase, etc. |  [optional]
 **unicodeEnabled** | **Boolean** | Format of the message. It indicates whether the content should be treated as unicode or not.  |  [optional]
 **webUrl** | **String** | Webhook to call for each event triggered by the message (delivered etc.) |  [optional]
 **templateId** | **Integer** | Template ID to send SMS with the template. When provided, overrides the content parameter. Either &#39;templateId&#39; or &#39;content&#39; must be provided, but not both. |  [optional]
 **content** | **String** | Content of the message. If more than **160 characters** long, will be sent as multiple text messages. Either &#39;templateId&#39; or &#39;content&#39; must be provided, but not both. Mandatory if &#39;templateId&#39; is not passed, ignored if &#39;templateId&#39; is passed.  |  [optional]
+**params** | **Map&lt;String, Object&gt;** | Pass the set of attributes to customize the template. For example, {&quot;FNAME&quot;:&quot;Joe&quot;, &quot;LNAME&quot;:&quot;Doe&quot;}. These are the placeholder variables in the template that will be replaced with the corresponding values passed in the params object. Applicable only if &#x60;templateId&#x60; is used. |  [optional]
 
 
 <a name="TypeEnum"></a>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.brevo</groupId>
     <artifactId>brevo</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <packaging>jar</packaging>
 
     <name>brevo</name>

--- a/src/main/java/brevoModel/SendTransacSms.java
+++ b/src/main/java/brevoModel/SendTransacSms.java
@@ -22,6 +22,8 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * SendTransacSms
@@ -38,7 +40,7 @@ public class SendTransacSms {
   private String sender = null;
 
   @SerializedName("tag")
-  private String tag = null;
+  private SendTransacSmsTag tag = null;
 
   /**
    * Type of the SMS. Marketing SMS messages are those sent typically with marketing content. Transactional SMS messages are sent to individuals and are triggered in response to some action, such as a sign-up, purchase, etc.
@@ -102,6 +104,9 @@ public class SendTransacSms {
   @SerializedName("content")
   private String content = null;
 
+  @SerializedName("params")
+  private Map<String, Object> params = null;
+
   public SendTransacSms organisationPrefix(String organisationPrefix) {
     this.organisationPrefix = organisationPrefix;
     return this;
@@ -156,21 +161,21 @@ public class SendTransacSms {
     this.sender = sender;
   }
 
-  public SendTransacSms tag(String tag) {
+  public SendTransacSms tag(SendTransacSmsTag tag) {
     this.tag = tag;
     return this;
   }
 
    /**
-   * Tag of the message. Can be a string or an array of strings (e.g., &quot;accountValidation&quot; or [&quot;tag1&quot;, &quot;tag2&quot;]).
+   * Tag of the message
    * @return tag
   **/
-  @ApiModelProperty(example = "accountValidation", value = "Tag of the message. Can be a string or an array of strings (e.g., \"accountValidation\" or [\"tag1\", \"tag2\"]).")
-  public String getTag() {
+  @ApiModelProperty(example = "accountValidation | [\"tag1\", \"tag2\"]", value = "Tag of the message")
+  public SendTransacSmsTag getTag() {
     return tag;
   }
 
-  public void setTag(String tag) {
+  public void setTag(SendTransacSmsTag tag) {
     this.tag = tag;
   }
 
@@ -252,7 +257,7 @@ public class SendTransacSms {
   }
 
    /**
-   * Content of the message. If more than **160 characters** long, will be sent as multiple text messages. Either &#39;templateId&#39; or &#39;content&#39; must be provided, but not both. Mandatory if &#39;templateId&#39; is not passed, ignored if &#39;templateId&#39; is passed. 
+   * Content of the message. If more than **160 characters** long, will be sent as multiple text messages. Either &#39;templateId&#39; or &#39;content&#39; must be provided, but not both. Mandatory if &#39;templateId&#39; is not passed, ignored if &#39;templateId&#39; is passed.
    * @return content
   **/
   @ApiModelProperty(example = "Enter this code:CCJJG8 to validate your account", value = "Content of the message. If more than **160 characters** long, will be sent as multiple text messages. Either 'templateId' or 'content' must be provided, but not both. Mandatory if 'templateId' is not passed, ignored if 'templateId' is passed. ")
@@ -262,6 +267,32 @@ public class SendTransacSms {
 
   public void setContent(String content) {
     this.content = content;
+  }
+
+  public SendTransacSms params(Map<String, Object> params) {
+    this.params = params;
+    return this;
+  }
+
+  public SendTransacSms putParamsItem(String key, Object paramsItem) {
+    if (this.params == null) {
+      this.params = new HashMap<String, Object>();
+    }
+    this.params.put(key, paramsItem);
+    return this;
+  }
+
+   /**
+   * Pass the set of attributes to customize the template. For example, {&quot;FNAME&quot;:&quot;Joe&quot;, &quot;LNAME&quot;:&quot;Doe&quot;}. These are the placeholder variables in the template that will be replaced with the corresponding values passed in the params object. Applicable only if &#x60;templateId&#x60; is used.
+   * @return params
+  **/
+  @ApiModelProperty(example = "{\"FNAME\":\"Joe\",\"LNAME\":\"Doe\"}", value = "Pass the set of attributes to customize the template. For example, {\"FNAME\":\"Joe\", \"LNAME\":\"Doe\"}. These are the placeholder variables in the template that will be replaced with the corresponding values passed in the params object. Applicable only if `templateId` is used.")
+  public Map<String, Object> getParams() {
+    return params;
+  }
+
+  public void setParams(Map<String, Object> params) {
+    this.params = params;
   }
 
 
@@ -282,12 +313,13 @@ public class SendTransacSms {
     ObjectUtils.equals(this.unicodeEnabled, sendTransacSms.unicodeEnabled) &&
     ObjectUtils.equals(this.webUrl, sendTransacSms.webUrl) &&
     ObjectUtils.equals(this.templateId, sendTransacSms.templateId) &&
-    ObjectUtils.equals(this.content, sendTransacSms.content);
+    ObjectUtils.equals(this.content, sendTransacSms.content) &&
+    ObjectUtils.equals(this.params, sendTransacSms.params);
   }
 
   @Override
   public int hashCode() {
-    return ObjectUtils.hashCodeMulti(organisationPrefix, recipient, sender, tag, type, unicodeEnabled, webUrl, templateId, content);
+    return ObjectUtils.hashCodeMulti(organisationPrefix, recipient, sender, tag, type, unicodeEnabled, webUrl, templateId, content, params);
   }
 
 
@@ -305,6 +337,7 @@ public class SendTransacSms {
     sb.append("    webUrl: ").append(toIndentedString(webUrl)).append("\n");
     sb.append("    templateId: ").append(toIndentedString(templateId)).append("\n");
     sb.append("    content: ").append(toIndentedString(content)).append("\n");
+    sb.append("    params: ").append(toIndentedString(params)).append("\n");
     sb.append("}");
     return sb.toString();
   }


### PR DESCRIPTION
 1. New params field — Added a Map<String, Object> params field to support template variable substitution when using templateId. Example: {"FNAME": "Joe", "LNAME":   
  "Doe"}. Includes getter, setter, and a putParamsItem builder method.                                                                                               
  2. tag type change — The tag field was changed from String to the dedicated SendTransacSmsTag type, allowing it to represent either a single string or an array of   
  strings more accurately.                                                                                                                                             
  3. equals / hashCode updated — Both methods now include the new params field.
  4. Docs updated — SendTransacSms.md reflects the new params field and the updated tag type reference. 