### PR TITLE
Fix maven-gpg-plugin incorrectly declared as compile dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,12 +97,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.1.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>


### PR DESCRIPTION
## Summary
- `maven-gpg-plugin` was accidentally added to the `<dependencies>` section with no scope (defaulting to `compile`), causing it and its transitive dependencies (`org.apache.maven.*`, `org.sonatype.sisu.*`, `org.apache.maven.shared.*`) to leak to all consumers of this library
- Consumers were forced to add manual `exclude` blocks to work around this
- Fix removes the misplaced `<dependency>` entry — the plugin is already correctly declared in `<build><plugins>` where it belongs

## Test plan
- [ ] Verify `mvn dependency:tree` no longer includes `maven-gpg-plugin` or its transitive deps in the published POM
- [ ] Confirm consumers can use the library without needing `exclude` blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)