### PR TITLE
feat: N8N-3709 | Update tag field type in SendTransacSms from SendTransacSmsTag to String  

### DIFF
--- a/docs/SendTransacSms.md
+++ b/docs/SendTransacSms.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **organisationPrefix** | **String** | A recognizable prefix will ensure your audience knows who you are. Recommended by U.S. carriers. This will be added as your Brand Name before the message content. **Prefer verifying maximum length of 160 characters including this prefix in message content to avoid multiple sending of same sms.** |  [optional]
 **recipient** | **String** | Mobile number to send SMS with the country code |
 **sender** | **String** | Name of the sender. **The number of characters is limited to 11 for alphanumeric characters and 15 for numeric characters**  |
-**tag** | [**SendTransacSmsTag**](SendTransacSmsTag.md) | Tag of the message |  [optional]
+**tag** | **String** | Tag of the message. Can be a string or an array of strings (e.g., &quot;accountValidation&quot; or [&quot;tag1&quot;, &quot;tag2&quot;]). |  [optional]
 **type** | [**TypeEnum**](#TypeEnum) | Type of the SMS. Marketing SMS messages are those sent typically with marketing content. Transactional SMS messages are sent to individuals and are triggered in response to some action, such as a sign-up, purchase, etc. |  [optional]
 **unicodeEnabled** | **Boolean** | Format of the message. It indicates whether the content should be treated as unicode or not.  |  [optional]
 **webUrl** | **String** | Webhook to call for each event triggered by the message (delivered etc.) |  [optional]

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.brevo</groupId>
     <artifactId>brevo</artifactId>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <packaging>jar</packaging>
 
     <name>brevo</name>

--- a/src/main/java/brevoModel/SendTransacSms.java
+++ b/src/main/java/brevoModel/SendTransacSms.java
@@ -40,7 +40,7 @@ public class SendTransacSms {
   private String sender = null;
 
   @SerializedName("tag")
-  private SendTransacSmsTag tag = null;
+  private String tag = null;
 
   /**
    * Type of the SMS. Marketing SMS messages are those sent typically with marketing content. Transactional SMS messages are sent to individuals and are triggered in response to some action, such as a sign-up, purchase, etc.
@@ -161,21 +161,21 @@ public class SendTransacSms {
     this.sender = sender;
   }
 
-  public SendTransacSms tag(SendTransacSmsTag tag) {
+  public SendTransacSms tag(String tag) {
     this.tag = tag;
     return this;
   }
 
    /**
-   * Tag of the message
+   * * Tag of the message. Can be a string or an array of strings (e.g., &quot;accountValidation&quot; or [&quot;tag1&quot;, &quot;tag2&quot;]).
    * @return tag
   **/
-  @ApiModelProperty(example = "accountValidation | [\"tag1\", \"tag2\"]", value = "Tag of the message")
-  public SendTransacSmsTag getTag() {
+   @ApiModelProperty(example = "accountValidation", value = "Tag of the message. Can be a string or an array of strings (e.g., \"accountValidation\" or [\"tag1\", \"tag2\"]).")
+   public String getTag() {
     return tag;
   }
 
-  public void setTag(SendTransacSmsTag tag) {
+  public void setTag(String tag) {
     this.tag = tag;
   }
 

--- a/swagger_definition_client.yml
+++ b/swagger_definition_client.yml
@@ -1,0 +1,25028 @@
+x-samples-languages: ['curl']
+swagger: '2.0'
+info:
+  version: '3.0.0'
+  title: Brevo API
+  description: |
+    Brevo provide a RESTFul API that can be used with any languages. With this API, you will be able to :
+      - Manage your campaigns and get the statistics
+      - Manage your contacts
+      - Send transactional Emails and SMS
+      - and much more...
+
+    You can download our wrappers at https://github.com/orgs/brevo
+
+    **Possible responses**
+      | Code | Message |
+      | :-------------: | ------------- |
+      | 200  | OK. Successful Request  |
+      | 201  | OK. Successful Creation |
+      | 202  | OK. Request accepted |
+      | 204  | OK. Successful Update/Deletion  |
+      | 400  | Error. Bad Request  |
+      | 401  | Error. Authentication Needed  |
+      | 402  | Error. Not enough credit, plan upgrade needed  |
+      | 403  | Error. Permission denied  |
+      | 404  | Error. Object does not exist |
+      | 405  | Error. Method not allowed  |
+      | 406  | Error. Not Acceptable  |
+      | 422  | Error. Unprocessable Entity |
+  contact:
+    name: Brevo Support
+    email: contact@brevo.com
+    url: https://account.brevo.com/support
+  license:
+    name: MIT
+    url: http://opensource.org/licenses/MIT
+host: api.brevo.com
+basePath: /v3
+schemes:
+  - https
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /emailCampaigns:
+    get:
+        tags:
+          - Email Campaigns
+        summary: Return all your created email campaigns
+        operationId: getEmailCampaigns
+        parameters:
+          - name: type
+            description: Filter on the type of the campaigns
+            in: query
+            required: false
+            type: string
+            enum:
+              - classic
+              - trigger
+          - name: status
+            description: Filter on the status of the campaign
+            in: query
+            required: false
+            type: string
+            enum:
+              - suspended
+              - archive
+              - sent
+              - queued
+              - draft
+              - inProcess
+              - inReview
+          - name: statistics
+            description : Filter on the type of statistics required. Example **globalStats** value will only fetch globalStats info of the campaign in returned response.This option only returns data for events occurred in the last 6 months.For older campaigns, it’s advisable to use the **Get Campaign Report** endpoint.
+            in : query
+            required : false
+            type : string
+            enum :
+              - globalStats
+              - linksStats
+              - statsByDomain
+          - name: startDate
+            description: Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
+            in: query
+            required: false
+            type: string
+          - name: endDate
+            description: Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
+            in: query
+            required: false
+            type: string
+          - name: limit
+            description: Number of documents per page
+            in: query
+            required: false
+            type: integer
+            format: int64
+            default: 50
+            maximum: 100
+            minimum: 0
+          - name: offset
+            description: Index of the first document in the page
+            in: query
+            required: false
+            type: integer
+            format: int64
+            default: 0
+          - name: sort
+            in: query
+            description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+            required: false
+            type: string
+            enum:
+              - asc
+              - desc
+            default: desc
+          - name: excludeHtmlContent
+            in : query
+            description: Use this flag to exclude htmlContent from the response body. If set to **true**, htmlContent field will be returned as empty string in the response body
+            type : boolean
+            enum :
+              - true
+              - false
+        responses:
+            '200':
+              description: Email campaigns informations
+              schema:
+                $ref: '#/definitions/getEmailCampaigns'
+              examples:
+                applications/json:
+                    {
+                      "campaigns": [
+                        {
+                          "id": 12,
+                          "name": "EN - Sales Summer 2017",
+                          "subject": "20% OFF for 2017 Summer Sales",
+                          "previewText": "Don't miss the sale!",
+                          "type": "classic",
+                          "status": "sent",
+                          "scheduledAt": "2017-06-01T12:30:00Z",
+                          "testSent": true,
+                          "header": "[DEFAULT_HEADER]",
+                          "footer": "[DEFAULT_FOOTER]",
+                          "sender": {
+                            "email": "marketing@mycompany.com",
+                            "name": "Marketing",
+                            "id": 26
+                          },
+                          "replyTo": "replyto@domain.com",
+                          "toField": "{FNAME} {LNAME}",
+                          "htmlContent": "This is my HTML Content",
+                          "shareLink": "http://example.com/fhsgccc.html?t=9865448900",
+                          "tag": "Newsletter",
+                          "createdAt": "2017-05-01T12:30:00Z",
+                          "modifiedAt": "2017-05-01T12:30:00Z",
+                          "inlineImageActivation": true,
+                          "mirrorActive": true,
+                          "recurring": false,
+                          "recipients": {
+                            "lists": [
+                              5
+                            ],
+                            "exclusionLists": [
+                              13
+                            ]
+                          },
+                          "statistics": {
+                            "globalStats": {
+                              "uniqueClicks": 2300,
+                              "clickers": 2665,
+                              "complaints": 1,
+                              "delivered": 19765,
+                              "sent": 19887,
+                              "softBounces": 100,
+                              "hardBounces": 87,
+                              "uniqueViews": 7779,
+                              "trackableViews": 5661,
+                              "trackableViewsRate": 23.45,
+                              "estimatedViews": 560,
+                              "unsubscriptions": 2,
+                              "viewed": 8999,
+                              "opensRate": 29.54,
+                              "appleMppOpens": 10
+                            },
+                            "campaignStats": [
+                              {
+                                "listId": 5,
+                                "uniqueClicks": 2300,
+                                "clickers": 2665,
+                                "complaints": 1,
+                                "delivered": 19765,
+                                "sent": 19887,
+                                "softBounces": 100,
+                                "hardBounces": 87,
+                                "uniqueViews": 7779,
+                                "trackableViews": 5661,
+                                "unsubscriptions": 2,
+                                "viewed": 8999,
+                                "deferred": 30
+                              }
+                            ],
+                            "mirrorClick": 120,
+                            "remaining": 1000,
+                            "linksStats": {
+                              "http://myUrl1.domain.com": 80
+                            },
+                            "statsByDomain": {
+                              "yahoo": {
+                                "uniqueClicks": 2300,
+                                "clickers": 2665,
+                                "complaints": 1,
+                                "delivered": 19765,
+                                "sent": 19887,
+                                "softBounces": 100,
+                                "hardBounces": 87,
+                                "uniqueViews": 7779,
+                                "unsubscriptions": 2,
+                                "viewed": 8999,
+                                "deferred": 30
+                              },
+                              "gmail": {
+                                "uniqueClicks": 2300,
+                                "clickers": 2665,
+                                "complaints": 1,
+                                "delivered": 19765,
+                                "sent": 19887,
+                                "softBounces": 100,
+                                "hardBounces": 87,
+                                "uniqueViews": 7779,
+                                "unsubscriptions": 2,
+                                "viewed": 8999,
+                                "deferred": 30
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "id": 22,
+                          "name": "Weekly - 1",
+                          "subject": "Week 1 - Newsletter",
+                          "previewText": "your weekly newsletter!",
+                          "type": "Classic",
+                          "status": "draft",
+                          "scheduledAt": "",
+                          "testSent": false,
+                          "header": "[DEFAULT_HEADER]",
+                          "footer": "[DEFAULT_FOOTER]",
+                          "sender": {
+                            "email": "newsletter@mycompany.com",
+                            "name": "Newsletter",
+                            "id": 26
+                          },
+                          "replyTo": "replyto@domain.com",
+                          "toField": "{FNAME} {LNAME}",
+                          "htmlContent": "This is my HTML Content",
+                          "shareLink": "http://example.com/fhsgccc.html?t=9865448900",
+                          "tag": "Newsletter",
+                          "createdAt": "2017-05-01T12:30:00Z",
+                          "modifiedAt": "2017-05-01T12:30:00Z",
+                          "inlineImageActivation": true,
+                          "mirrorActive": true,
+                          "recurring": false,
+                          "recipients": {
+                            "lists": [
+                              10
+                            ],
+                            "exclusionLists": [
+                              45
+                            ]
+                          },
+                          "statistics": {
+                            "globalStats": {
+                              "uniqueClicks": 2300,
+                              "clickers": 2665,
+                              "complaints": 1,
+                              "delivered": 19765,
+                              "sent": 19887,
+                              "softBounces": 100,
+                              "hardBounces": 87,
+                              "uniqueViews": 7779,
+                              "trackableViews": 5661,
+                              "trackableViewsRate": 23.45,
+                              "estimatedViews": 560,
+                              "unsubscriptions": 2,
+                              "viewed": 8999,
+                              "opensRate": 29.54,
+                              "appleMppOpens": 10
+                            },
+                            "campaignStats": [
+                              {
+                                "listId": 10,
+                                "uniqueClicks": 2300,
+                                "clickers": 2665,
+                                "complaints": 1,
+                                "delivered": 19765,
+                                "sent": 19887,
+                                "softBounces": 100,
+                                "hardBounces": 87,
+                                "uniqueViews": 7779,
+                                "trackableViews": 5661,
+                                "unsubscriptions": 2,
+                                "viewed": 8999,
+                                "deferred": 30
+                              }
+                            ],
+                            "mirrorClick": 120,
+                            "remaining": 1000,
+                            "linksStats": {
+                              "http://myUrl1.domain.com": {
+                                "nbClick": 80
+                              },
+                              "http://myUrl2.domain.com": {
+                                "nbClick": 80
+                              },
+                              "http://myUrl3.domain.com": {
+                                "nbClick": 80
+                              }
+                            },
+                            "statsByDomain": {
+                              "yahoo.com": {
+                                  "uniqueClicks": 298,
+                                  "clickers": 533,
+                                  "complaints": 0,
+                                  "sent": 25601,
+                                  "softBounces": 5,
+                                  "hardBounces": 0,
+                                  "uniqueViews": 3527,
+                                  "unsubscriptions": 17,
+                                  "viewed": 5255,
+                                  "delivered": 25596
+                              },
+                              "hotmail.co.uk": {
+                                  "uniqueClicks": 1970,
+                                  "clickers": 2720,
+                                  "complaints": 5,
+                                  "sent": 117055,
+                                  "softBounces": 111,
+                                  "hardBounces": 0,
+                                  "uniqueViews": 21111,
+                                  "unsubscriptions": 105,
+                                  "viewed": 35251,
+                                  "delivered": 117056
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "count": 2
+                    }
+            '400':
+              description: bad request
+              schema:
+                $ref: '#/definitions/errorModel'
+    post:
+       tags:
+          - Email Campaigns
+       summary: Create an email campaign
+       operationId: createEmailCampaign
+       parameters:
+        - name: emailCampaigns
+          description: Values to create a campaign
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/createEmailCampaign'
+       responses:
+          '201':
+            description: Email campaign created
+            schema:
+              $ref: '#/definitions/createModel'
+          '400':
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+  /emailCampaigns/{campaignId}:
+    get:
+      tags:
+          - Email Campaigns
+      summary: Get an email campaign report
+      operationId: getEmailCampaign
+      parameters:
+        - name: campaignId
+          description: Id of the campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: statistics
+          description : Filter on the type of statistics required. Example **globalStats** value will only fetch globalStats info of the campaign in returned response.
+          in: query
+          type: string
+          required: false
+          enum :
+            - globalStats
+            - linksStats
+            - statsByDomain
+            - statsByDevice
+            - statsByBrowser
+      responses:
+        '200':
+          description: Email campaign informations
+          schema:
+            $ref: '#/definitions/getEmailCampaign'
+          examples:
+            application/json:
+                {
+                  "id": 22,
+                  "name": "Weekly - 1",
+                  "subject": "Week 1 - Newsletter",
+                  "previewText": "your weekly newsletter!",
+                  "type": "classic",
+                  "status": "draft",
+                  "scheduledAt": "2017-09-22T12:30:00Z",
+                  "testSent": false,
+                  "header": "[DEFAULT_HEADER]",
+                  "footer": "[DEFAULT_FOOTER]",
+                  "sender": {
+                    "email": "newsletter@mycompany.com",
+                    "name": "Newsletter",
+                    "id": 26
+                  },
+                  "replyTo": "replyto@domain.com",
+                  "toField": "{FNAME} {LNAME}",
+                  "htmlContent": "This is my HTML Content",
+                  "shareLink": "http://dhh.brevo.com/fhsgccc.html?t=9865448900",
+                  "tag": "Newsletter",
+                  "createdAt": "2017-05-01T12:30:00Z",
+                  "modifiedAt": "2017-05-01T12:30:00Z",
+                  "inlineImageActivation": true,
+                  "mirrorActive": true,
+                  "recurring": false,
+                  "recipients": {
+                    "lists": [
+                      22
+                    ],
+                    "exclusionLists": [
+                      45
+                    ]
+                  },
+                  "statistics": {
+                    "globalStats": {
+                      "uniqueClicks": 2300,
+                      "clickers": 2665,
+                      "complaints": 1,
+                      "delivered": 19765,
+                      "sent": 19887,
+                      "softBounces": 100,
+                      "hardBounces": 87,
+                      "uniqueViews": 7779,
+                      "trackableViews": 5661,
+                      "trackableViewsRate": 23.45,
+                      "estimatedViews": 560,
+                      "unsubscriptions": 2,
+                      "viewed": 8999,
+                      "opensRate": 29.54,
+                      "appleMppOpens": 10
+                    },
+                    "campaignStats": [
+                      {
+                        "listId": 22,
+                        "uniqueClicks": 2300,
+                        "clickers": 2665,
+                        "complaints": 1,
+                        "delivered": 19765,
+                        "sent": 19887,
+                        "softBounces": 100,
+                        "hardBounces": 87,
+                        "uniqueViews": 7779,
+                        "trackableViews": 5661,
+                        "unsubscriptions": 2,
+                        "viewed": 8999,
+                        "deferred": 30
+                      }
+                    ],
+                    "mirrorClick": 120,
+                    "remaining": 1000,
+                    "linksStats": {
+                      "http://myUrl1.domain.com": {
+                        "nbClick": 80
+                      },
+                      "http://myUrl2.domain.com": {
+                        "nbClick": 80
+                      },
+                      "http://myUrl3.domain.com": {
+                        "nbClick": 80
+                      }
+                    },
+                    "statsByDomain": {
+                      "gmail": {
+                        "uniqueClicks": 2300,
+                        "clickers": 2665,
+                        "complaints": 1,
+                        "delivered": 19765,
+                        "sent": 19887,
+                        "softBounces": 100,
+                        "hardBounces": 87,
+                        "uniqueViews": 7779,
+                        "unsubscriptions": 2,
+                        "viewed": 8999,
+                        "deferred": 30
+                      }
+                    },
+                    "statsByDevice": {
+                      "desktop": {
+                        "mac": {
+                          "clickers": 1,
+                          "uniqueClicks": 0,
+                          "viewed": 2,
+                          "uniqueViews": 1
+                        }
+                      },
+                      "mobile": {
+                        "androidMobile": {
+                          "clickers": 1,
+                          "uniqueClicks": 0,
+                          "viewed": 1,
+                          "uniqueViews": 0
+                        },
+                        "iPhone": {
+                          "clickers": 1,
+                          "uniqueClicks": 0,
+                          "viewed": 2,
+                          "uniqueViews": 0
+                        }
+                      }
+                    },
+                    "statsByBrowser": {
+                      "thunderbird": {
+                        "clickers": 1,
+                        "uniqueClicks": 0,
+                        "viewed": 1,
+                        "uniqueViews": 0
+                      },
+                      "safari": {
+                        "clickers": 1,
+                        "uniqueClicks": 0,
+                        "viewed": 1,
+                        "uniqueViews": 0
+                      },
+                      "internetExplorer": {
+                        "clickers": 0,
+                        "uniqueClicks": 0,
+                        "viewed": 1,
+                        "uniqueViews": 0
+                      }
+                    }
+                  }
+                }
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+          - Email Campaigns
+      summary: Update an email campaign
+      operationId: updateEmailCampaign
+      parameters:
+        - name: campaignId
+          description: Id of the campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: emailCampaign
+          description: Values to update a campaign
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/updateEmailCampaign'
+      responses:
+        '204':
+          description: Email Campaign has been updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+          - Email Campaigns
+      summary: Delete an email campaign
+      operationId: deleteEmailCampaign
+      parameters:
+        - name: campaignId
+          description: id of the campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '204':
+          description: Email campaign has been deleted
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /emailCampaigns/{campaignId}/sendNow:
+    post:
+      tags:
+          - Email Campaigns
+      summary: Send an email campaign immediately, based on campaignId
+      operationId: sendEmailCampaignNow
+      parameters:
+        - name: campaignId
+          description: Id of the campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '204':
+          description: Email campaign has been scheduled
+        '400':
+          description: Campaign could not be sent
+          schema:
+            $ref: '#/definitions/errorModel'
+        '402':
+          description: You don't have enough credit to send your campaign. Please update your plan
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /emailCampaigns/{campaignId}/sendTest:
+    post:
+      tags:
+          - Email Campaigns
+      summary: Send an email campaign to your test list
+      operationId: sendTestEmail
+      parameters:
+      - name: campaignId
+        description: Id of the campaign
+        in: path
+        type: integer
+        format: int64
+        required: true
+      - name: emailTo
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/sendTestEmail'
+      responses:
+        '204':
+          description: Test email has been sent successfully to all recipients
+        '400':
+          description: Test email could not be sent to the following email addresses
+          schema:
+            $ref: '#/definitions/postSendFailed'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /emailCampaigns/{campaignId}/status:
+    put:
+      tags:
+          - Email Campaigns
+      summary: Update an email campaign status
+      operationId: updateCampaignStatus
+      parameters:
+        - name: campaignId
+          description: Id of the campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: status
+          description: Status of the campaign
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/updateCampaignStatus'
+      responses:
+        '204':
+          description: The campaign status has been updated successfully
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /emailCampaigns/{campaignId}/sendReport:
+    post:
+      tags:
+          - Email Campaigns
+      summary: Send the report of a campaign
+      description: A PDF will be sent to the specified email addresses
+      operationId: sendReport
+      parameters:
+      - name: campaignId
+        description: Id of the campaign
+        in: path
+        type: integer
+        format: int64
+        required: true
+      - name: sendReport
+        description: Values for send a report
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/sendReport'
+      responses:
+        '204':
+          description: Report has been successfully sent to the defined recipients
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /emailCampaigns/{campaignId}/abTestCampaignResult:
+    get:
+      tags:
+        - Email Campaigns
+      summary: Get an A/B test email campaign results
+      description: Obtain winning version of an A/B test email campaign
+      operationId: getAbTestCampaignResult
+      parameters:
+        - name: campaignId
+          description: Id of the A/B test campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '200':
+          description: A/B test email campaign Result
+          schema:
+            $ref: '#/definitions/abTestCampaignResult'
+          examples:
+            application/json:
+              {
+                "winningVersion": "B",
+                "winningCriteria": "Click",
+                "openRate": "100%",
+                "clickRate": "50%",
+                "winningVersionRate": "0%",
+                "statistics": {
+                  "openers": {
+                    "Version A": "20%",
+                    "Version B": "100%"
+                  },
+                  "clicks": {
+                    "Version A": "0%",
+                    "Version B": "50%"
+                  },
+                  "unsubscribed": {
+                    "Version A": "20%",
+                    "Version B": "0%"
+                  },
+                  "softBounces": {
+                    "Version A": "0%",
+                    "Version B": "0%"
+                  },
+                  "hardBounces": {
+                    "Version A": "0%",
+                    "Version B": "0%"
+                  },
+                  "complaints": {
+                    "Version A": "0%",
+                    "Version B": "0%"
+                  }
+                },
+                "clickedLinks": {
+                  "Version A": [
+                    {
+                      "link": "http://www.google.com",
+                      "clicksCount": 0,
+                      "clickRate": "0%"
+                    },
+                    {
+                      "link": "http://www.youtube.com",
+                      "clicksCount": 0,
+                      "clickRate": "0%"
+                    }
+                  ],
+                  "Version B": [
+                    {
+                      "link": "http://www.github.com",
+                      "clicksCount": 2,
+                      "clickRate": "40%"
+                    },
+                    {
+                      "link": "http://www.stackoverflow.com",
+                      "clicksCount": 3,
+                      "clickRate": "60%"
+                    }
+                  ]
+                }
+              }
+        '404':
+          description: A/B test Email Campaign not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '405':
+          description: Only email campaigns or templates are allowed
+          schema:
+            $ref: '#/definitions/errorModel'
+  /emailCampaigns/{campaignId}/sharedUrl:
+    get:
+      tags:
+        - Email Campaigns
+      summary: Get a shared template url
+      description: Get a unique URL to share & import an email template from one Brevo account to another.
+      operationId: getSharedTemplateUrl
+      parameters:
+        - name: campaignId
+          description: Id of the campaign or template
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '200':
+          description: Shared template URL information
+          schema:
+            $ref: '#/definitions/getSharedTemplateUrl'
+          examples:
+            application/json:
+              {
+                "sharedUrl": "https://my.brevo.com/pt2YU7R5W_guXlowgumy_VX4pFsKu._zd0Gjj96x1_GMmzc1Qps5ZIpj6nx-",
+              }
+        '404':
+          description: Campaign/Template ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /emailCampaigns/{campaignId}/exportRecipients:
+    post:
+      tags:
+          - Email Campaigns
+      summary: Export the recipients of an email campaign
+      operationId: emailExportRecipients
+      parameters:
+        - name: campaignId
+          description: Id of the campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: recipientExport
+          description: Values to send for a recipient export request
+          in: body
+          required: false
+          schema:
+            $ref: '#/definitions/emailExportRecipients'
+      responses:
+        '202':
+          description: Recipient export request has been accepted
+          schema:
+            $ref: '#/definitions/createdProcessId'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /emailCampaigns/images:
+    post:
+      tags:
+        - Email Campaigns
+      summary: Upload an image to your account's image gallery
+      operationId: uploadImageToGallery
+      parameters:
+        - name: uploadImage
+          description: Parameters to upload an image
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/uploadImageToGallery'
+      responses:
+          '201':
+            description: Image successfully uploaded
+            schema:
+              $ref: '#/definitions/uploadImageModel'
+          '400':
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+
+  /smtp/email:
+    post:
+      tags:
+          - Transactional emails
+      summary: Send a transactional email
+      operationId: sendTransacEmail
+      parameters:
+        - name: sendSmtpEmail
+          description: Values to send a transactional email
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/sendSmtpEmail'
+      responses:
+        '201':
+          description: transactional email sent
+          schema:
+            $ref: '#/definitions/createSmtpEmail'
+        '202':
+          description: transactional email scheduled
+          schema:
+            $ref: '#/definitions/scheduleSmtpEmail'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/emails:
+    get:
+      tags:
+        - Transactional emails
+      summary: Get the list of transactional emails on the basis of allowed filters
+      description: This endpoint will show the list of emails for past 30 days by default. To retrieve emails before that time, please pass startDate and endDate in query filters.
+      operationId: getTransacEmailsList
+      parameters:
+        - name: email
+          description: Mandatory if templateId and messageId are not passed in query filters. Email address to which transactional email has been sent.
+          in: query
+          required: false
+          type: string
+        - name: templateId
+          description: Mandatory if email and messageId are not passed in query filters. Id of the template that was used to compose transactional email.
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: messageId
+          description: Mandatory if templateId and email are not passed in query filters. Message ID of the transactional email sent.
+          in: query
+          required: false
+          type: string
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Maximum time period that can be selected is one month.
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month.
+          in: query
+          required: false
+          type: string
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+        - name: limit
+          description: Number of documents returned per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 500
+          maximum: 1000
+          minimum: 0
+        - name: offset
+          description: Index of the first document in the page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default : 0
+      responses:
+        '200':
+          description: List of transactional emails
+          schema:
+            $ref: '#/definitions/getTransacEmailsList'
+          examples:
+            application/json:
+              {
+                "count": 120,
+                "transactionalEmails": [
+                  {
+                    "email": "abc@xyz.com",
+                    "subject": "summer camp",
+                    "templateId": 15,
+                    "messageId": "<201798300811.5787683@relay.domain.com>",
+                    "uuid": "5a78c-209ok98262910-std2341",
+                    "date": "2019-05-25T11:53:26Z"
+                  },
+                  {
+                    "email": "test@test.com",
+                    "subject": "details verification",
+                    "templateId": 15,
+                    "messageId": "<201798300811.5700093@relay.domain.com>",
+                    "uuid": "5a78c-209ok98262910-s99a341",
+                    "date": "2019-05-25T07:28:11Z"
+                  }
+                ]
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/emails/{uuid}:
+    get:
+      tags:
+        - Transactional emails
+      summary: Get the personalized content of a sent transactional email
+      operationId: getTransacEmailContent
+      parameters:
+        - name: uuid
+          description: Unique id of the transactional email that has been sent to a particular contact
+          in: path
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Transactional email content
+          schema:
+            $ref: '#/definitions/getTransacEmailContent'
+          examples:
+            application/json:
+              {
+                "email": "abc@example.com",
+                "subject": "Summer Camps",
+                "templateId": 12,
+                "date": "2016-02-25T11:53:26Z",
+                "events": [{
+                  "name": "sent",
+                  "time": "2016-02-25T11:53:26Z"
+                }, {
+                  "name": "delivered",
+                  "time": "2016-02-25T11:55:26Z"
+                }, {
+                  "name": "opened",
+                  "time": "2016-02-26T09:53:26Z"
+                }],
+                "body": "<!DOCTYPE html> <html> <body> <h1>Greetings from the team</h1> <p>This is the actual html content sent</p> </body> </html>"
+              }
+  /smtp/log/{identifier}:
+    delete:
+      tags:
+          - Transactional emails
+      summary: Delete an SMTP transactional log
+      parameters:
+        - name: identifier
+          description: MessageId of the transactional log(s) to delete
+          in: path
+          type: string
+          required: true
+      responses:
+        '204':
+          description: Transactional Logs deleted
+        '404':
+          description: Message ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/templates:
+    get:
+      tags:
+          - Transactional emails
+      summary: Get the list of email templates
+      operationId: getSmtpTemplates
+      parameters:
+        - name: templateStatus
+          description: Filter on the status of the template. Active = true, inactive = false
+          in: query
+          required: false
+          type: boolean
+        - name: limit
+          description: Number of documents returned per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 50
+          maximum: 1000
+          minimum: 0
+        - name: offset
+          description: Index of the first document in the page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default : 0
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: transactional email templates informations
+          schema:
+            $ref: '#/definitions/getSmtpTemplates'
+          examples:
+            application/json:
+                {
+                  "count": 2,
+                  "templates": [
+                  {
+                    "id": 5,
+                    "name": "ChristomasTimeTemplate",
+                    "subject": "Merry Christmas",
+                    "isActive": false,
+                    "testSent": false,
+                    "sender": {
+                      "name": "John",
+                      "email": "john.smith@example.com",
+                      "id": 23
+                    },
+                    "replyTo": "replyto@domain.com",
+                    "toField": "",
+                    "tag": "Festival",
+                    "htmlContent": "HTML CONTENT 1",
+                    "createdAt": "2016-02-24T14:44:24Z",
+                    "modifiedAt": "2016-02-24T15:37:11Z"
+                  },
+                  {
+                    "id": 12,
+                    "name": "SummerSales2017Template",
+                    "subject": "Enjoy our summer Sales !",
+                    "isActive": true,
+                    "testSent": false,
+                     "sender": {
+                      "name": "John",
+                      "email": "john.smith@example.com",
+                      "id": 23
+                    },
+                    "replyTo": "replyto@domain.com",
+                    "toField": "",
+                    "tag":"Summer",
+                    "htmlContent": "HTML CONTENT 2",
+                    "createdAt": "2016-02-25T11:53:26Z",
+                    "modifiedAt": "2016-02-25T11:53:26Z"
+                  }
+                ]
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+          - Transactional emails
+      summary: Create an email template
+      operationId: createSmtpTemplate
+      parameters:
+        - name: smtpTemplate
+          description: values to update in transactional email template
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/createSmtpTemplate'
+      responses:
+        '201':
+          description: transactional email template created
+          schema:
+            $ref: '#/definitions/createModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/templates/{templateId}:
+    get:
+      tags:
+          - Transactional emails
+      summary: Returns the template information
+      operationId: getSmtpTemplate
+      parameters:
+        - name: templateId
+          description: id of the template
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '200':
+          description: Email template informations
+          schema:
+            $ref: '#/definitions/getSmtpTemplateOverview'
+          examples:
+            application/json:
+              {
+                "id": 33,
+                "name": "OrderConfirmation",
+                "subject": "Order Confirmation : Thanks for your Purchase !",
+                "isActive": true,
+                "testSent": false,
+                "sender": {
+                  "name": "John",
+                  "email": "john.smith@example.com",
+                  "id": 26
+                },
+                "replyTo": "replyto@domain.com",
+                "toField": "",
+                "tag": "",
+                "htmlContent": "HTML CONTENT 4",
+                "createdAt": "2016-02-25T11:53:26Z",
+                "modifiedAt": "2016-02-25T11:53:26Z",
+                "doiTemplate": false
+              }
+        '404':
+          description: Template ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+          - Transactional emails
+      summary: Update an email template
+      operationId: updateSmtpTemplate
+      parameters:
+        - name: templateId
+          description: id of the template
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: smtpTemplate
+          description: values to update in transactional email template
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/updateSmtpTemplate'
+      responses:
+        '204':
+          description: transactional email template updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Template ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+          - Transactional emails
+      summary: Delete an inactive email template
+      operationId: deleteSmtpTemplate
+      parameters:
+        - name: templateId
+          description: id of the template
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '204':
+          description: Inactive transactional email template has been deleted
+        '404':
+          description: Template ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/templates/{templateId}/sendTest:
+    post:
+      tags:
+          - Transactional emails
+      summary: Send a template to your test list
+      operationId: sendTestTemplate
+      parameters:
+      - name: templateId
+        description: Id of the template
+        in: path
+        type: integer
+        format: int64
+        required: true
+      - name: sendTestEmail
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/sendTestEmail'
+      responses:
+        '204':
+          description: Test email has been sent successfully to all recipients
+        '400':
+          description: Test email could not be sent to the following email addresses
+          schema:
+            $ref: '#/definitions/postSendFailed'
+        '404':
+          description: Template ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/template/preview:
+    post:
+      tags:
+          - Transactional emails
+      summary: Generate the rendered preview of transactional template
+      operationId: postPreviewSmtpEmailTemplates
+      parameters:
+        - name: fetchTemplatePreview
+          description: Values to fetch Template preview
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/fetchTemplatePreview'
+      responses:
+        '200':
+          description: successfully fetched template's preview fields
+          schema:
+            $ref: '#/definitions/templatePreview'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/statistics/aggregatedReport:
+    get:
+      tags:
+          - Transactional emails
+      summary: Get your transactional email activity aggregated over a period of time
+      description: This endpoint will show the aggregated stats for past 90 days by default if `startDate` and `endDate` OR `days` is not passed. The date range can not exceed 90 days
+      operationId: getAggregatedSmtpReport
+      parameters:
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date of the report (YYYY-MM-DD). Must be lower than equal to endDate
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD). Must be greater than equal to startDate
+          in: query
+          required: false
+          type: string
+        - name: days
+          description: Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: tag
+          description: Tag of the emails
+          in: query
+          required: false
+          type: string
+      responses:
+        '200':
+          description: Aggregated report informations
+          schema:
+            $ref: '#/definitions/getAggregatedReport'
+          examples:
+            application/json:
+              {
+                "range": "2016-09-08|2017-04-28",
+                "requests": 19887,
+                "delivered": 18996,
+                "hardBounces": 234,
+                "softBounces": 1533,
+                "clicks": 9987,
+                "uniqueClicks": 8766,
+                "opens": 17654,
+                "uniqueOpens": 13688,
+                "spamReports": 1,
+                "blocked": 2,
+                "invalid": 0,
+                "unsubscribed": 2
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/statistics/reports:
+    get:
+      tags:
+          - Transactional emails
+      summary: Get your transactional email activity aggregated per day
+      operationId: getSmtpReport
+      parameters:
+        - name: limit
+          description: Number of documents returned per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 10
+          maximum: 30
+          minimum: 0
+        - name: offset
+          description: Index of the first document on the page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 0
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date of the report (YYYY-MM-DD)
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD)
+          in: query
+          required: false
+          type: string
+        - name: days
+          description: Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: tag
+          description: Tag of the emails
+          in: query
+          required: false
+          type: string
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: Aggregated report informations
+          schema:
+            $ref: '#/definitions/getReports'
+          examples:
+            application/json:
+              { "reports": [
+                  {
+                    "date":"2017-04-30",
+                    "requests":10756,
+                    "delivered":10103,
+                    "hardBounces":21,
+                    "softBounces":137,
+                    "clicks":1026,
+                    "uniqueClicks":720,
+                    "opens":5091,
+                    "uniqueOpens":2318,
+                    "spamReports":0,
+                    "blocked":519,
+                    "invalid":1,
+                    "unsubscribed": 0
+                  },
+                  {
+                    "date":"2017-05-01",
+                    "requests":18812,
+                    "delivered":17499,
+                    "hardBounces":34,
+                    "softBounces":254,
+                    "clicks":1514,
+                    "uniqueClicks":1090,
+                    "opens":10089,
+                    "uniqueOpens":4393,
+                    "spamReports":0,
+                    "blocked":920,
+                    "invalid":2,
+                    "unsubscribed": 3
+                  }
+                ]
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/statistics/events:
+    get:
+      tags:
+          - Transactional emails
+      summary: Get all your transactional email activity (unaggregated events)
+      description: This endpoint will show the aggregated stats for past 30 days by default if `startDate` and `endDate` OR `days` is not passed. The date range can not exceed 90 days
+      operationId: getEmailEventReport
+      parameters:
+        - name: limit
+          description: Number limitation for the result returned
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 2500
+          maximum: 5000
+          minimum: 0
+        - name: offset
+          description: Beginning point in the list to retrieve from.
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 0
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date of the report (YYYY-MM-DD). Must be lower than equal to endDate
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD). Must be greater than equal to startDate
+          in: query
+          required: false
+          type: string
+        - name: days
+          description: Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: email
+          description: Filter the report for a specific email addresses
+          in: query
+          required: false
+          type: string
+          format: email
+        - name: event
+          description: Filter the report for a specific event type
+          in: query
+          required: false
+          type: string
+          enum:
+           - bounces
+           - hardBounces
+           - softBounces
+           - delivered
+           - spam
+           - requests
+           - opened
+           - clicks
+           - invalid
+           - deferred
+           - blocked
+           - unsubscribed
+           - error
+           - loadedByProxy
+        - name: tags
+          description: Filter the report for tags (serialized and urlencoded array)
+          in: query
+          required: false
+          type: string
+        - name: messageId
+          description: Filter on a specific message id
+          in: query
+          required: false
+          type: string
+        - name: templateId
+          description: Filter on a specific template id
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: Email events report informations
+          schema:
+            $ref: '#/definitions/getEmailEventReport'
+          examples:
+            application/json:
+                {
+                  "events": [
+                    {
+                      "email": "john.smith@example.com",
+                      "date": "2017-03-12T12:30:00Z",
+                      "messageId": "<201798300811.5787683@example.domain.com>",
+                      "event": "deferred",
+                      "reason": "Error connection timeout",
+                      "tag": "OrderConfirmation",
+                      "from": "john@example.com",
+                      "templateId": 4
+                    },
+                     {
+                      "email": "john.smith@example.com",
+                      "date": "2017-03-13T16:30:00Z",
+                      "messageId": "<201798300811.5787683@example.domain.com>",
+                      "event": "delivered",
+                      "tag": "OrderConfirmation",
+                      "from": "john@example.com",
+                      "templateId": 5
+                    }
+                  ]
+                }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/blockedContacts/{email}:
+    delete:
+      tags:
+          - Transactional emails
+      summary: Unblock or resubscribe a transactional contact
+      parameters:
+        - name: email
+          description: contact email (urlencoded) to unblock.
+          in: path
+          type: string
+          required: true
+      responses:
+        '204':
+          description: Contact unblocked
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Contact email not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/blockedContacts:
+    get:
+      tags:
+        - Transactional emails
+      summary: Get the list of blocked or unsubscribed transactional contacts
+      operationId: getTransacBlockedContacts
+      parameters:
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date (YYYY-MM-DD) from which you want to fetch the blocked or unsubscribed contacts
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date (YYYY-MM-DD) till which you want to fetch the blocked or unsubscribed contacts
+          in: query
+          required: false
+          type: string
+        - name: limit
+          description: Number of documents returned per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 50
+          maximum: 100
+          minimum: 0
+        - name: offset
+          description: Index of the first document on the page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 0
+        - name: senders
+          description: Comma separated list of emails of the senders from which contacts are blocked or unsubscribed
+          in: query
+          required: false
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: List of blocked or unsubscribed transactional contacts
+          schema:
+            $ref: '#/definitions/getTransacBlockedContacts'
+          examples:
+            application/json:
+              {
+                "contacts": [
+                  {
+                    "email": "abc@xyz.com",
+                    "senderEmail": "ez312@gmal.com",
+                    "reason": {
+                        "message": "Admin blocked",
+                        "code": "adminBlocked"
+                    },
+                    "blockedAt": "2017-05-01T12:30:00Z",
+                  }
+                ],
+                "count": 1
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/blockedDomains:
+    get:
+      tags:
+        - Transactional emails
+      summary: Get the list of blocked domains
+      description: Get the list of blocked domains
+      operationId: getBlockedDomains
+      responses:
+        '200':
+          description: List of blocked domains
+          schema:
+            $ref: '#/definitions/getBlockedDomains'
+          examples:
+            application/json:
+              {
+                "domains": ["example.com", "testdomain.com"]
+              }
+    post:
+      tags:
+        - Transactional emails
+      summary: Add a new domain to the list of blocked domains
+      description: Blocks a new domain in order to avoid messages being sent to the same
+      operationId: blockNewDomain
+      parameters:
+        - name: blockDomain
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/blockDomain'
+      responses:
+        '201':
+          description: Domain is successfully blocked
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/blockedDomains/{domain}:
+    delete:
+      tags:
+        - Transactional emails
+      summary: Unblock an existing domain from the list of blocked domains
+      description: Unblocks an existing domain from the list of blocked domains
+      operationId: deleteBlockedDomain
+      parameters:
+        - name: domain
+          description: The name of the domain to be deleted
+          type: string
+          in: path
+          required: true
+      responses:
+        '204':
+          description: Domain is successfully deleted from the list of blocked domains
+        '404':
+          description: Domain not found
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/deleteHardbounces:
+    post:
+      tags:
+          - Transactional emails
+      summary: Delete hardbounces
+      description: Delete hardbounces. To use carefully (e.g. in case of temporary ISP failures)
+      operationId: deleteHardbounces
+      parameters:
+        - name: deleteHardbounces
+          description: values to delete hardbounces
+          in: body
+          required: false
+          schema:
+            $ref: '#/definitions/deleteHardbounces'
+      responses:
+        '204':
+          description: Hardbounces deleted
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/emailStatus/{batchId}:
+    get:
+      tags:
+      - Transactional emails
+      summary: Fetch scheduled emails by batchId
+      description: Fetch scheduled batch of emails by batchId (Can retrieve data upto 30 days old)
+      operationId: getScheduledEmailByBatchId
+      parameters:
+        - name: batchId
+          type: string
+          description: The batchId of scheduled emails batch (Should be a valid UUIDv4)
+          in: path
+          required: true
+        - name: startDate
+          description: Mandatory if `endDate` is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Can be maximum 30 days older tha current date.
+          type: string
+          format: date
+          in: query
+          required: false
+        - name: endDate
+          description: Mandatory if `startDate` is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month.
+          type: string
+          format: date
+          in: query
+          required: false
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+        - name: status
+          in: query
+          description: Filter the records by `status` of the scheduled email batch or message.
+          required: false
+          type: string
+          enum:
+            - processed
+            - inProgress
+            - queued
+        - name: limit
+          description: Number of documents returned per page
+          in: query
+          type: integer
+          format: int64
+          default: 100
+          maximum: 500
+          minimum: 0
+          required: false
+        - name: offset
+          description: Index of the first document on the page
+          in: query
+          type: integer
+          format : int64
+          default: 0
+          required: false
+      responses:
+        200:
+          description: Scheduled email batches
+          schema:
+            $ref: '#/definitions/getScheduledEmailByBatchId'
+          examples:
+            application/json:
+              {
+                  "count": 3,
+                  "batches": [
+                      {
+                          "scheduledAt": "2022-02-28T11:36:43.576000000Z",
+                          "createdAt": "2022-02-26T11:36:43.576000000Z",
+                          "status": "queued"
+                      },
+                      {
+                          "scheduledAt": "2022-02-25T11:36:43.576000000Z",
+                          "createdAt": "2022-02-24T11:36:43.576000000Z",
+                          "status": "processed"
+                      },
+                      {
+                          "scheduledAt": "2022-02-26T11:36:43.576000000Z",
+                          "createdAt": "2022-02-25T11:36:43.576000000Z",
+                          "status": "inProgress"
+                      }
+                  ]
+              }
+        400:
+          description: Invalid parameters passed
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Records for batchId not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/emailStatus/{messageId}:
+    get:
+      tags:
+      - Transactional emails
+      summary: Fetch scheduled email by messageId
+      description: Fetch scheduled email by messageId (Can retrieve data upto 30 days old)
+      operationId: getScheduledEmailByMessageId
+      parameters:
+        - name: messageId
+          description: The messageId of scheduled email
+          in: path
+          type: string
+          required: true
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Can be maximum 30 days older tha current date.
+          in: query
+          type: string
+          format: date
+          required: false
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month.
+          in: query
+          type: string
+          format: date
+          required: false
+      responses:
+        200:
+          description: Scheduled email
+          schema:
+            $ref: '#/definitions/getScheduledEmailByMessageId'
+          examples:
+            application/json:
+                {
+                    "scheduledAt": "2022-02-28T11:36:43.576000000Z",
+                    "createdAt": "2022-02-26T11:36:43.576000000Z",
+                    "status": "queued"
+                }
+        400:
+          description: Invalid parameters passed
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Record for messageId not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smtp/email/{identifier}:
+    delete:
+      tags:
+      - Transactional emails
+      summary: Delete scheduled emails by batchId or messageId
+      description: Delete scheduled batch of emails by batchId or single scheduled email by messageId
+      operationId: deleteScheduledEmailById
+      parameters:
+        - name: identifier
+          description: The `batchId` of scheduled emails batch (Should be a valid UUIDv4) or the `messageId` of scheduled email.
+          type: string
+          in: path
+          required: true
+      responses:
+        '204':
+          description: Scheduled email(s) deleted
+        '400':
+          description: Invalid parameters passed
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Record(s) for identifier not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts:
+    get:
+      tags:
+          - Contacts
+      summary: Get all the contacts
+      operationId: getContacts
+      parameters:
+        - name: limit
+          description: Number of documents per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 50
+          maximum: 1000
+          minimum: 0
+        - name: offset
+          description: Index of the first document of the page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 0
+        - name: modifiedSince
+          description: Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
+          in: query
+          required: false
+          type: string
+        - name: createdSince
+          description: Filter (urlencoded) the contacts created after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
+          in: query
+          required: false
+          type: string
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+        - name: segmentId
+          description: Id of the segment. **Either listIds or segmentId can be passed.**
+          in: query
+          type: integer
+          format: int64
+        - name: listIds
+          description: Ids of the list. **Either listIds or segmentId can be passed.**
+          in: query
+          type: array
+          items:
+            type: integer
+            format: int64
+        - name: filter
+          in: query
+          description: |
+            Filter the contacts on the basis of attributes. **Allowed operator: equals. For multiple-choice options, the filter will apply an AND condition between the options. For category attributes, the filter will work with both id and value. (e.g. filter=equals(FIRSTNAME,"Antoine"), filter=equals(B1, true), filter=equals(DOB, "1989-11-23"), filter=equals(GENDER, "1"), filter=equals(GENDER, "MALE"), filter=equals(COUNTRY,"USA, INDIA")**
+          type: string
+      responses:
+        '200':
+          description: All contacts listed
+          schema:
+            $ref: '#/definitions/getContacts'
+          examples:
+            application/json:
+              {
+                "contacts": [
+                  {
+                  "email": "contact1@example.com",
+                  "id": 247,
+                  "emailBlacklisted": true,
+                  "smsBlacklisted": true,
+                  "createdAt": "2017-05-01T17:05:03Z",
+                  "modifiedAt": "2017-05-01T17:05:03Z",
+                  "listIds": [43,58],
+                  "attributes": {
+                    "SMS": "33058407250",
+                    "IDENTIFICATION": "1-3RHQ-259",
+                    "CIV": "MS",
+                    "LAST_NAME": "Brennon",
+                    "FIRST_NAME": "Meg",
+                    "DOB": "1986-05-02",
+                    "ADDRESS": "1 5th avenue",
+                    "ZIP_CODE": "44300",
+                    "CITY": "New-York",
+                    "ACTION_CODE": "17HH98CH",
+                    }
+                  },
+                  {
+                  "email": "33058407248@mailin-sms.com",
+                  "id": 245,
+                  "emailBlacklisted": true,
+                  "smsBlacklisted": false,
+                  "createdAt": "2017-05-01T17:05:03Z",
+                  "modifiedAt": "2017-05-01T17:05:03Z",
+                  "listIds": [43,61,58],
+                  "attributes": {
+                    "SMS": "33058407248",
+                    "IDENTIFICATION": "1-78JS-432",
+                    "CIV": "MS",
+                    "LAST_NAME": "Press",
+                    "FIRST_NAME": "Sophia",
+                    "DOB": "1980-09-11",
+                    "ADDRESS": "5 Flower Street",
+                    "ZIP_CODE": "44119",
+                    "CITY": "Seattle",
+                    "ACTION_CODE": "17HU765",
+                    }
+                  }
+                ],
+              "count": 3
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '429':
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+          - Contacts
+      summary: Create a contact
+      description: Creates new contacts on Brevo. Contacts can be created by passing either - <br><br>
+        1. email address of the contact (email_id),  <br>
+        2. phone number of the contact (to be passed as "SMS" field in "attributes" along with proper country code), For example- {"SMS":"+91xxxxxxxxxx"} or {"SMS":"0091xxxxxxxxxx"} <br>
+        3. ext_id <br>
+      operationId: createContact
+      parameters:
+        - name: createContact
+          description: Values to create a contact
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/createContact'
+      responses:
+        '201':
+          description: Contact created
+          schema:
+            $ref: '#/definitions/createUpdateContactModel'
+        '204':
+          description: Contact updated
+          examples:
+            application/json:
+              {}
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/contactErrorModel'
+        '425':
+          description: Too Early
+          schema:
+            $ref: '#/definitions/contactErrorModel'
+  /contacts/doubleOptinConfirmation:
+    post:
+      tags:
+          - Contacts
+      summary: Create Contact via DOI (Double-Opt-In) Flow
+      operationId: createDoiContact
+      parameters:
+        - name: createDoiContact
+          description: Values to create the Double opt-in (DOI) contact
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/createDoiContact'
+      responses:
+        '201':
+          description: DOI Contact created
+        '204':
+          description: DOI Contact updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/{identifier}:
+    get:
+      tags:
+          - Contacts
+      summary: Get a contact's details
+      description: There are 2 ways to get a contact <br><br>
+        Option 1- https://api.brevo.com/v3/contacts/{identifier} <br><br>
+        Option 2- https://api.brevo.com/v3/contacts/{identifier}?identifierType={} <br>
+        <br>
+        Option 1 only works if identifierType is email_id (for EMAIL), phone_id (for SMS) or contact_id (for ID of the contact),where you can directly pass the value of EMAIL, SMS and ID of the contact.   <br><br>
+        Option 2 works for all identifierType, use email_id for EMAIL attribute, phone_id for SMS attribute, contact_id for ID of the contact, ext_id for EXT_ID attribute, whatsapp_id for WHATSAPP attribute, landline_number_id for LANDLINE_NUMBER attribute <br><br>Along with the contact details, this endpoint will show the statistics of contact for the recent 90 days by default. To fetch the earlier statistics, please use Get contact campaign stats ``https://developers.brevo.com/reference/contacts-7#getcontactstats`` endpoint with the appropriate date ranges.
+      operationId: getContactInfo
+      parameters:
+        - name: identifier
+          description: Email (urlencoded) OR ID of the contact OR its SMS attribute value OR EXT_ID attribute (urlencoded)
+          in: path
+          type: string
+          required: true
+        - name: identifierType
+          in: query
+          description: email_id for Email, phone_id for SMS attribute, contact_id for ID of the contact, ext_id for EXT_ID attribute, whatsapp_id for WHATSAPP attribute, landline_number_id for LANDLINE_NUMBER attribute
+          type: string
+          enum:
+          - email_id
+          - phone_id
+          - contact_id
+          - ext_id
+          - whatsapp_id
+          - landline_number_id
+        - name: startDate
+          in: query
+          description: |
+            **Mandatory if endDate is used.** Starting date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be lower than equal to endDate
+          type: string
+        - name: endDate
+          in: query
+          description: |
+            **Mandatory if startDate is used.** Ending date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be greater than equal to startDate.
+          type: string
+      responses:
+        '200':
+          description: Contact informations
+          schema:
+            $ref: '#/definitions/getExtendedContactDetails'
+          examples:
+            application/json:
+              {
+                "email": "peggy.rain@example.com",
+                "id": 42,
+                "emailBlacklisted": false,
+                "smsBlacklisted": false,
+                "createdAt": "2017-05-02T16:40:31Z",
+                "modifiedAt": "2017-05-02T16:40:31Z",
+                "attributes": {
+                  "FIRST_NAME": "Peggy",
+                  "LAST_NAME": "Rain",
+                  "SMS": "3087433387669",
+                  "CIV": "1",
+                  "DOB": "1986-04-13",
+                  "ADDRESS": "987 5th avenue",
+                  "ZIP_CODE": "87544",
+                  "CITY": "New-York",
+                  "AREA": "NY"
+                  },
+                "listIds": [40],
+                "statistics": {
+                  "messagesSent": [
+                    {
+                      "campaignId": 21,
+                      "eventTime": "2016-05-03T20:15:13Z"
+                    },
+                    {
+                      "campaignId": 42,
+                      "eventTime": "2016-10-17T10:30:01Z"
+                    }
+                  ],
+                  "opened": [
+                    {
+                      "campaignId": 21,
+                      "count": 2,
+                      "eventTime": "2016-05-03T21:24:56Z",
+                      "ip": "66.249.93.118"
+                    },
+                    {
+                      "campaignId": 68,
+                      "count": 1,
+                      "eventTime": "2017-01-30T13:56:40Z",
+                      "ip": "66.249.93.217"
+                    }
+                  ],
+                  "clicked": [
+                    {
+                      "campaignId": 21,
+                      "links":[
+                        {
+                          "count": 2,
+                          "eventTime": "2016-05-03T21:25:01Z",
+                          "ip": "66.249.93.118",
+                          "url": "https://url.domain.com/fbe5387ec717e333628380454f68670010b205ff/1/go?uid={EMAIL}&utm_source=brevo&utm_campaign=test_camp&utm_medium=email"
+                        }
+                      ],
+                    },
+                  ],
+                  "delivered": [
+                    {
+                      "campaignId": 21,
+                      "eventTime": "2016-05-03T20:15:13Z"
+                    }
+                  ]
+                }
+              }
+        '404':
+          description: Contact's email not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+          - Contacts
+      summary: Delete a contact
+      description: There are 2 ways to delete a contact <br><br>
+        Option 1- https://api.brevo.com/v3/contacts/{identifier} <br><br>
+        Option 2- https://api.brevo.com/v3/contacts/{identifier}?identifierType={} <br>
+        <br>
+        Option 1 only works if identifierType is email_id (for EMAIL) or contact_id (for ID of the contact),where you can directly pass the value of EMAIL and ID of the contact.   <br><br>
+        Option 2 works for all identifierType, use email_id for EMAIL attribute, contact_id for ID of the contact, ext_id for EXT_ID attribute, phone_id for SMS attribute, whatsapp_id for WHATSAPP attribute, landline_number_id for LANDLINE_NUMBER attribute.
+      operationId: deleteContact
+      parameters:
+        - name: identifier
+          description: Email (urlencoded) OR ID of the contact OR EXT_ID attribute (urlencoded)
+          in: path
+          type: string
+          required: true
+        - name: identifierType
+          in: query
+          description: email_id for Email, contact_id for ID of the contact, ext_id for EXT_ID attribute, phone_id for SMS attribute, whatsapp_id for WHATSAPP attribute, landline_number_id for LANDLINE_NUMBER attribute
+          type: string
+          enum:
+          - email_id
+          - contact_id
+          - ext_id
+          - phone_id
+          - whatsapp_id
+          - landline_number_id
+      responses:
+        '204':
+          description: Contact deleted
+        '404':
+          description: Contact not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '405':
+          description: You're not allowed to delete registered email contact with Brevo
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+          - Contacts
+      summary: Update a contact
+      description: There are 2 ways to update a contact <br><br>
+        Option 1- https://api.brevo.com/v3/contacts/{identifier} <br><br>
+        Option 2- https://api.brevo.com/v3/contacts/{identifier}?identifierType={} <br>
+        <br>
+        Option 1 only works if identifierType is email_id (for EMAIL) or contact_id (for ID of the contact),where you can directly pass the value of EMAIL and ID of the contact.   <br><br>
+        Option 2 works for all identifierType, use email_id for EMAIL attribute, contact_id for ID of the contact, ext_id for EXT_ID attribute, phone_id for SMS attribute, whatsapp_id for WHATSAPP attribute, landline_number_id for LANDLINE attribute
+      operationId: updateContact
+      parameters:
+        - name: identifier
+          description: Email (urlencoded) OR ID of the contact OR EXT_ID attribute (urlencoded) OR its SMS attribute value OR its WHATSAPP attribute value OR its LANDLINE attribute value
+          in: path
+          type: string
+          required: true
+        - name: identifierType
+          in: query
+          description: email_id for Email, contact_id for ID of the contact, ext_id for EXT_ID attribute, phone_id for SMS attribute, whatsapp_id for WHATSAPP attribute, landline_number_id for LANDLINE attribute
+          type: string
+          enum:
+          - email_id
+          - contact_id
+          - ext_id
+          - phone_id
+          - whatsapp_id
+          - landline_number_id
+        - name: updateContact
+          description: Values to update a contact
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/updateContact'
+      responses:
+        '204':
+          description: Contact updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/contactErrorModel'
+        '404':
+          description: Contact's email not found
+          schema:
+            $ref: '#/definitions/contactErrorModel'
+        '425':
+          description: Too Early
+          schema:
+            $ref: '#/definitions/contactErrorModel'
+  /contacts/batch:
+    post:
+      tags:
+          - Contacts
+      summary: Update multiple contacts
+      operationId: updateBatchContacts
+      parameters:
+        - name: updateBatchContacts
+          description: Values to update multiple contacts
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/updateBatchContacts'
+      responses:
+        '204':
+          description: All contacts updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/{identifier}/campaignStats:
+    get:
+      tags:
+          - Contacts
+      summary: Get email campaigns' statistics for a contact
+      operationId: getContactStats
+      parameters:
+        - name: identifier
+          description: Email (urlencoded) OR ID of the contact
+          in: path
+          type: string
+          required: true
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be lower than equal to endDate
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the statistic events specific to campaigns. Must be greater than equal to startDate. Maximum difference between startDate and endDate should not be greater than 90 days
+          in: query
+          required: false
+          type: string
+      responses:
+        '200':
+          description: Contact campaign statistics informations
+          schema:
+            $ref: '#/definitions/getContactCampaignStats'
+          examples:
+            application/json:
+              {
+                "messagesSent": [
+                  {
+                    "campaignId": 21,
+                    "eventTime": "2016-05-03T20:15:13Z"
+                  },
+                  {
+                    "campaignId": 42,
+                    "eventTime": "2016-10-17T10:30:01Z"
+                  },
+                  {
+                    "campaignId": 45,
+                    "eventTime": "2016-11-09T11:45:02Z"
+                  }
+                ],
+                "opened": [
+                  {
+                    "campaignId": 21,
+                    "count": 2,
+                    "eventTime": "2016-05-03T21:24:56Z",
+                    "ip": "66.249.93.118"
+                  },
+                  {
+                    "campaignId": 45,
+                    "count": 1,
+                    "eventTime": "2017-01-30T13:56:40Z",
+                    "ip": "66.249.93.217"
+                  }
+                ],
+                "clicked": [
+                  {
+                    "campaignId": 21,
+                    "links":[
+                      {
+                        "count": 2,
+                        "eventTime": "2016-05-03T21:25:01Z",
+                        "ip": "66.249.93.118",
+                        "url": "https://url.domain.com/fbe5387ec717e333628380454f68670010b205ff/1/go?uid={EMAIL}&utm_source=brevo&utm_campaign=test_camp&utm_medium=email"
+                      }
+                    ],
+                  },
+                ],
+                "delivered": [
+                  {
+                    "campaignId": 21,
+                    "eventTime": "2016-05-03T20:15:13Z"
+                  }
+                ]
+              }
+        '404':
+          description: Contact's email not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/attributes:
+    get:
+      tags:
+          - Contacts
+      summary: List all attributes
+      operationId: getAttributes
+      responses:
+        '200':
+          description: Attributes listed
+          schema:
+            $ref: '#/definitions/getAttributes'
+          examples:
+            application/json:
+                {
+                  "attributes": [
+                    {
+                      "name": "LASTNAME",
+                      "category": "normal",
+                      "type": "text",
+                    },
+                    {
+                      "name": "FIRSTNAME",
+                      "category": "normal",
+                      "type": "text",
+                    },
+                    {
+                      "name": "DOB",
+                      "category": "normal",
+                      "type": "date",
+                    },
+                    {
+                      "name": "GENDER",
+                      "category": "category",
+                      "type": "text",
+                      "enumeration": [
+                        {
+                          "value": 1,
+                          "label": "Men"
+                        },
+                        {
+                          "value": 2,
+                          "label": "Women"
+                        },
+                        {
+                          "value": 3,
+                          "label": "Kid"
+                        }
+                      ],
+                    },
+                    {
+                      "name": "BDO",
+                      "category": "normal",
+                      "type": "user",
+                    },
+                    {
+                      "name": "COUNTRY",
+                      "category": "normal",
+                      "type": "multiple-choice",
+                      "multiCategoryOptions": [
+                        "2 Play",
+                        "1 Dance"
+                      ]
+                    }
+                  ]
+                }
+  /contacts/attributes/{attributeCategory}/{attributeName}:
+    post:
+      tags:
+          - Contacts
+      summary: Create contact attribute
+      operationId: createAttribute
+      parameters:
+        - name: attributeCategory
+          description: Category of the attribute
+          in: path
+          required: true
+          type: string
+          enum:
+            - normal
+            - transactional
+            - category
+            - calculated
+            - global
+        - name: attributeName
+          description: Name of the attribute
+          in: path
+          type: string
+          required: true
+        - name: createAttribute
+          description: Values to create an attribute
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/createAttribute'
+      responses:
+        '201':
+          description: Attribute created
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+          - Contacts
+      summary: Update contact attribute
+      operationId: updateAttribute
+      parameters:
+        - name: attributeCategory
+          description: Category of the attribute
+          in: path
+          required: true
+          type: string
+          enum:
+            - category
+            - calculated
+            - global
+            - normal
+        - name: attributeName
+          description: Name of the existing attribute
+          in: path
+          type: string
+          required: true
+        - name: updateAttribute
+          description: Values to update an attribute
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/updateAttribute'
+      responses:
+        '204':
+          description: Attribute updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Attribute not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+          - Contacts
+      summary: Delete an attribute
+      operationId: deleteAttribute
+      parameters:
+        - name: attributeCategory
+          description: Category of the attribute
+          in: path
+          required: true
+          type: string
+          enum:
+            - normal
+            - transactional
+            - category
+            - calculated
+            - global
+        - name: attributeName
+          description: Name of the existing attribute
+          in: path
+          type: string
+          required: true
+      responses:
+        '204':
+          description: Attribute deleted
+        '404':
+          description: Attribute not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/attributes/{attributeType}/{multipleChoiceAttribute}/{multipleChoiceAttributeOption}:
+    delete:
+      tags:
+          - Contacts
+      summary:  Delete a multiple-choice attribute option
+      operationId: deleteMultiAttributeOptions
+      parameters:
+        - name: attributeType
+          description: Type of the attribute
+          in: path
+          required: true
+          type: string
+          enum:
+            - multiple-choice
+        - name: multipleChoiceAttribute
+          description: Name of the existing multiple-choice attribute
+          in: path
+          type: string
+          required: true
+        - name: multipleChoiceAttributeOption
+          description: Name of the existing multiple-choice attribute option that you want to delete
+          in: path
+          type: string
+          required: true
+      responses:
+        '204':
+          description: Multiple-Choice Attribute Option Deleted Successfully.
+        '404':
+          description: Attribute not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/folders:
+    get:
+      tags:
+          - Contacts
+      summary: Get all folders
+      operationId: getFolders
+      parameters:
+        - name: limit
+          description: Number of documents per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 10
+          maximum: 50
+          minimum: 0
+        - name: offset
+          description: Index of the first document of the page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default : 0
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: Folders informations
+          schema:
+            $ref: '#/definitions/getFolders'
+          examples:
+            application/json:
+              {
+                "folders": [
+                  {
+                    "id": 42,
+                    "name": "Ninja_Form",
+                    "totalBlacklisted": 98,
+                    "totalSubscribers": 4567,
+                    "uniqueSubscribers": 4665
+                  },
+                  {
+                    "id": 29,
+                    "name": "Prestashop",
+                    "totalBlacklisted": 10,
+                    "totalSubscribers": 6543,
+                    "uniqueSubscribers": 6553
+                  }
+                  ],
+                "count": 2
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+          - Contacts
+      summary: Create a folder
+      operationId: createFolder
+      parameters:
+        - name: createFolder
+          description: Name of the folder
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/createUpdateFolder'
+      responses:
+        '201':
+          description: Folder created
+          schema:
+            $ref: '#/definitions/createModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+
+  /contacts/segments:
+    get:
+      tags:
+          - Contacts
+      summary: Get all the Segments
+      operationId: getSegments
+      parameters:
+        - name: limit
+          description: Number of documents per page
+          in: query
+          required: true
+          type: integer
+          format: int64
+          default: 10
+          maximum: 50
+          minimum: 0
+        - name: offset
+          description: Index of the first document of the page
+          in: query
+          required: true
+          type: integer
+          format: int64
+          default : 0
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: Segments informations
+          schema:
+            $ref: '#/definitions/getSegments'
+          examples:
+            application/json:
+              {
+                "segments": [
+                  {
+                    "id": 42,
+                    "segmentName": "Segment1",
+                    "categoryName": "Name1",
+                    "updatedAt": "2017-03-12T12:30:00Z",
+                  },
+                  {
+                    "id": 29,
+                    "segmentName": "Segment2",
+                    "categoryName": "Name2",
+                    "updatedAt": "2017-03-12T12:30:00Z",
+                  }
+                  ],
+                "count": 2
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/folders/{folderId}:
+    get:
+      tags:
+          - Contacts
+      summary: Returns a folder's details
+      operationId: getFolder
+      parameters:
+        - name: folderId
+          description: id of the folder
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '200':
+          description: Folder details
+          schema:
+            $ref: '#/definitions/getFolder'
+          examples:
+            application/json:
+              {
+                "id": 1,
+                "name": "Client_Folder",
+                "totalBlacklisted": 987,
+                "totalSubscribers": 16778,
+                "uniqueSubscribers": 17765
+              }
+        '404':
+          description: Folder ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+          - Contacts
+      summary: Update a folder
+      operationId: updateFolder
+      parameters:
+        - name: folderId
+          description: Id of the folder
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: updateFolder
+          description: Name of the folder
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/createUpdateFolder'
+      responses:
+        '204':
+          description: Folder updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Folder ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+          - Contacts
+      summary: Delete a folder (and all its lists)
+      operationId: deleteFolder
+      parameters:
+        - name: folderId
+          description: Id of the folder
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '204':
+          description: Folder deleted
+        '404':
+          description: Folder ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/folders/{folderId}/lists:
+    get:
+      tags:
+          - Contacts
+      summary: Get lists in a folder
+      operationId: getFolderLists
+      parameters:
+        - name: folderId
+          description: Id of the folder
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: limit
+          description: Number of documents per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 10
+          maximum: 50
+          minimum: 0
+        - name: offset
+          description: Index of the first document of the page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 0
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: Folder's Lists details
+          schema:
+            $ref: '#/definitions/getFolderLists'
+          examples:
+            application/json:
+              {
+                "lists": [
+                  {
+                  "id": 46,
+                  "name": "Reactiv",
+                  "totalSubscribers": 7655,
+                  "totalBlacklisted": 0,
+                  "uniqueSubscribers": 7655
+                  },
+                  {
+                  "id": 41,
+                  "name": "NY_Area",
+                  "totalSubscribers": 3654,
+                  "totalBlacklisted": 23,
+                  "uniqueSubscribers": 3677
+                  },
+                  {
+                  "id": 22,
+                  "name": "VIP_Customer",
+                  "totalSubscribers": 8753,
+                  "totalBlacklisted": 72,
+                  "uniqueSubscribers": 8826
+                  }
+                ],
+              "count": 3
+              }
+        '404':
+          description: Folder ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/lists:
+    get:
+      tags:
+          - Contacts
+      summary: Get all the lists
+      operationId: getLists
+      parameters:
+        - name: limit
+          description: Number of documents per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 10
+          maximum: 50
+          minimum: 0
+        - name: offset
+          description: Index of the first document of the page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 0
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: Lists informations
+          schema:
+            $ref: '#/definitions/getLists'
+          examples:
+            application/json:
+              {
+                "lists": [
+                  {
+                    "id": 53,
+                    "name": "Spanish_Speakers",
+                    "totalSubscribers": 5432,
+                    "totalBlacklisted": 65,
+                    "uniqueSubscribers": 5497,
+                    "folderId": 1
+                  },
+                  {
+                    "id": 50,
+                    "name": "Other",
+                    "totalSubscribers": 10976,
+                    "totalBlacklisted": 765,
+                    "uniqueSubscribers": 11741,
+                    "folderId": 2
+                  }
+                ],
+                "count": 2
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+          - Contacts
+      summary: Create a list
+      operationId: createList
+      parameters:
+        - name: createList
+          description: Values to create a list
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/createList'
+      responses:
+        '201':
+          description: List created
+          schema:
+            $ref: '#/definitions/createModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/lists/{listId}:
+    get:
+      tags:
+          - Contacts
+      summary: Get a list's details
+      operationId: getList
+      parameters:
+        - name: listId
+          description: Id of the list
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: startDate
+          description: Mandatory if endDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to aggregate the sent email campaigns for a specific list id.Prefer to pass your timezone in date-time format for accurate result
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to aggregate the sent email campaigns for a specific list id.Prefer to pass your timezone in date-time format for accurate result
+          in: query
+          required: false
+          type: string
+      responses:
+        '200':
+          description: List informations
+          schema:
+            $ref: '#/definitions/getExtendedList'
+          examples:
+            application/json:
+              {
+                "id": 12,
+                "name": "Newsletter_Weekly",
+                "startDate": "2023-10-10T00:00:00Z",
+                "endDate": "2024-04-10T00:00:00Z",
+                "totalSubscribers": 6533,
+                "totalBlacklisted": 63,
+                "uniqueSubscribers": 6596,
+                "folderId": 1,
+                "createdAt": "2016-02-26T11:56:08Z",
+                "campaignStats": [
+                  {
+                    "campaignId": 15,
+                    "stats": {
+                      "uniqueClicks": 701,
+                      "clickers": 789,
+                      "complaints": 0,
+                      "delivered": 6632,
+                      "sent": 6645,
+                      "softBounces": 34,
+                      "hardBounces": 4,
+                      "uniqueViews": 3442,
+                      "unsubscriptions": 4,
+                      "viewed": 4322,
+                      "deferred": 0
+                    }
+                  },
+                  {
+                    "campaignId": 45,
+                    "stats": {
+                      "uniqueClicks": 654,
+                      "clickers": 788,
+                      "complaints": 1,
+                      "delivered": 4078,
+                      "sent": 4334,
+                      "softBounces": 18,
+                      "hardBounces": 2,
+                      "uniqueViews": 987,
+                      "unsubscriptions": 4,
+                      "viewed": 1555,
+                      "deferred": 0
+                    }
+                  }
+                ],
+                "dynamicList": false
+              }
+        '404':
+          description: List ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+          - Contacts
+      summary: Update a list
+      operationId: updateList
+      parameters:
+        - name: listId
+          description: Id of the list
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: updateList
+          description: Values to update a list
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/updateList'
+      responses:
+        '204':
+          description: List updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: List ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+          - Contacts
+      summary: Delete a list
+      operationId: deleteList
+      parameters:
+        - name: listId
+          description: Id of the list
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '204':
+          description: List deleted
+        '404':
+          description: List ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/lists/{listId}/contacts:
+    get:
+      tags:
+          - Contacts
+      summary: Get contacts in a list
+      operationId: getContactsFromList
+      parameters:
+        - name: listId
+          description: Id of the list
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: modifiedSince
+          description: Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
+          in: query
+          required: false
+          type: string
+        - name: limit
+          description: Number of documents per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 50
+          maximum: 500
+          minimum: 0
+        - name: offset
+          description: Index of the first document of the page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 0
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: Contact informations
+          schema:
+            $ref: '#/definitions/getContacts'
+          examples:
+            application/json:
+                {
+                  "contacts": [
+                    {
+                      "email": "alex.pain@example.com",
+                      "id": 45,
+                      "emailBlacklisted": false,
+                      "smsBlacklisted": true,
+                      "createdAt": "2017-05-12T12:30:00Z",
+                      "modifiedAt": "2017-05-12T12:30:00Z",
+                      "listIds": [
+                        12,9,20
+                      ],
+                      "listUnsubscribed": [
+                        1,2
+                      ],
+                      "attributes": {
+                        "LASTNAME": "Pain",
+                        "FIRSTNAME": "Alex",
+                        "DOB": "2010-12-31",
+                        "GENDER": "Kid"
+                      },
+                    },
+                    {
+                      "email": "john.smith@example.com",
+                      "id": 32,
+                      "emailBlacklisted": true,
+                      "smsBlacklisted": false,
+                      "createdAt": "2017-05-12T12:30:00Z",
+                      "modifiedAt": "2017-05-12T12:30:00Z",
+                      "listIds": [
+                        12
+                      ],
+                      "listUnsubscribed": [
+                        1
+                      ],
+                      "attributes": {
+                        "LASTNAME": "Smith",
+                        "FIRSTNAME": "John",
+                        "DOB": "1986-06-21",
+                        "GENDER": "Men"
+                      }
+                    },
+                    {
+                      "email": "helen.rose@example.com",
+                      "id": 65,
+                      "emailBlacklisted": true,
+                      "smsBlacklisted": false,
+                      "createdAt": "2017-05-12T12:30:00Z",
+                      "modifiedAt": "2017-05-12T12:30:00Z",
+                      "listIds": [
+                        12,9,20
+                      ],
+                      "listUnsubscribed": [
+                        1
+                      ],
+                      "attributes": {
+                        "LASTNAME": "Rose",
+                        "FIRSTNAME": "Helen",
+                        "DOB": "1988-11-02",
+                        "GENDER": "Women",
+                        "SMS": "3375599887766",
+                      }
+                    }
+                  ],
+                  "count": 17655
+                }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: List ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/lists/{listId}/contacts/add:
+    post:
+      tags:
+          - Contacts
+      summary: Add existing contacts to a list
+      operationId: addContactToList
+      parameters:
+        - name: listId
+          description: Id of the list
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: contactEmails
+          description: Emails addresses OR IDs OR EXT_ID attributes of the contacts
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/addContactToList'
+      responses:
+        '201':
+          description: All contacts have been added successfully to the list with details of failed ones
+          schema:
+            $ref: '#/definitions/postContactInfo'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: List ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/lists/{listId}/contacts/remove:
+    post:
+      tags:
+          - Contacts
+      summary: Delete a contact from a list
+      operationId: removeContactFromList
+      parameters:
+        - name: listId
+          description: Id of the list
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: contactEmails
+          description: Emails addresses OR IDs OR EXT_ID attributes of the contacts
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/removeContactFromList'
+      responses:
+        '201':
+          description: All contacts have been removed successfully from the list with details of failed ones
+          schema:
+            $ref: '#/definitions/postContactInfo'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: List ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/export:
+    post:
+      tags:
+          - Contacts
+      summary : Export contacts
+      description:  It returns the background process ID which on completion calls the notify URL that you have set in the input. File will be available in csv.
+      operationId: requestContactExport
+      parameters:
+        - name: requestContactExport
+          description: Values to request a contact export
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/requestContactExport'
+      responses:
+        '202':
+          description: Contact export request has been accepted
+          schema:
+            $ref: '#/definitions/createdProcessId'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '429':
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/errorModel'
+  /contacts/import:
+    post:
+      tags:
+          - Contacts
+      summary: Import contacts
+      description: |
+        It returns the background process ID which on completion calls the notify URL that you have set in the input.
+
+        **Note**:
+        - Any contact attribute that doesn't exist in your account will be ignored at import end.
+      operationId: importContacts
+      parameters:
+        - name: requestContactImport
+          description: Values to import contacts in Brevo. To know more about the expected format, please have a look at ``https://help.brevo.com/hc/en-us/articles/209499265-Build-contacts-lists-for-your-email-marketing-campaigns``
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/requestContactImport'
+      responses:
+        '202':
+          description: Contact import request has been accepted
+          schema:
+            $ref: '#/definitions/createdProcessId'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /objects/{object_type}/batch/upsert:
+    post:
+      tags:
+      - Custom Objects
+      summary: Create/Update object records in bulk
+      description: |
+        This API allows bulk upsert of object records in a single request. Each object record may include
+          - Attributes
+          - Identifiers
+          - Associations
+
+        **Response:**
+          The API processes the request asynchronously and returns a processId that you can use to track the background process status.
+
+        **API and Schema Limitation:**
+          - Size:
+              - Max 1000 objects records per request
+              - Max request body size: 1 MB
+
+          - Max 500 attributes defined per object record upsert request
+            - This is coherent with schema limitation: an object cannot have more than 500 attributes.
+            - Worth noting: Nothing happens If an attribute is mentioned in the request, but was not previously defined for the object schema (no error, no attribute creation)
+
+          - Max 10 associations defined per object record upsert request
+            - This is coherent with schema limitation: an object cannot have more than 10 associations with other objects. and each object record can be linked to max 10 other records.
+
+        **Errors:**
+            - Make sure both object records exist before associating them, else the API will return an error.
+            - This route does not create objects. The object where the object records are upserted by this API must be created already else the API will return an error "invalid object type".
+      operationId: upsertrecords
+      parameters:
+        - name: object_type
+          in: path
+          description: 'object type for the attribute'
+          required: true
+          schema:
+            type: string
+            example: vehicle
+      requestBody:
+        description: Payload for batch upsert object records with associations
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                records:
+                  type: array
+                  minItems: 1
+                  maxItems: 1000
+                  description: List of object records to be upsert. Each record can have attributes, identifiers, and associations.
+                  items:
+                    oneOf:
+                      -   type: object
+                          properties:
+                            attributes:
+                              type: object
+                              description: |
+                                Attributes attached with the object record. Only the already created attributes will be used with records.
+                                Minimum 1 attribute is required.
+                              example:
+                                make: "Honda"
+                                model: "Civic"
+                                color: "Gray"
+                                year: 2021
+                                engine_type: "Diesel"
+                            identifiers:
+                              type: object
+                              description: |
+                                Identifiers attached with the object record. It can have id or ext_id. ext_id is ID of record in the external system that client want to store in the object system, id is an internal ID of object record generated by Brevo system.
+                                NOTE:
+                                - Its an optional field, if identifier is not provided, then id of object records will be generated by Brevo. This id can be used for further operation with the object record.
+                                - Both ext_id and id cannot be provided in the same request.
+                              example:
+                                id: 400
+                              properties:
+                                ext_id:
+                                  type: string
+                                  description: ext_id is ID of record in the external system that client want to store in the object system.
+                                id:
+                                  type: integer
+                                  description: Internal ID of the object record generated by Brevo
+                                  example: 16789
+                            associations:
+                              type: array
+                              minItems: 0
+                              maxItems: 10
+                              items:
+                                oneOf:
+                                  - type: object
+                                    properties:
+                                      object_type:
+                                        type: string
+                                        description: Type of the associated object
+                                        example: garage
+                                      records:
+                                        type: array
+                                        minItems: 1
+                                        maxItems: 100
+                                        items:
+                                          type: object
+                                          properties:
+                                            identifiers:
+                                              type: object
+                                              example:
+                                                id: 435435
+                                              properties:
+                                                ext_id:
+                                                  type: string
+                                                  description: ext_id is ID of record in the external system that client want to store in the object system.
+                                                  example: 9ab4c8d2ef
+                                                id:
+                                                  type: integer
+                                                  description: Internal ID of the object record generated by Brevo
+                                  - type: object
+                                    properties:
+                                      object_type:
+                                        type: string
+                                        description: Type of the associated object
+                                        example: insurance
+                                      records:
+                                        type: array
+                                        minItems: 1
+                                        maxItems: 100
+                                        items:
+                                          oneOf:
+                                            - type: object
+                                              properties:
+                                                identifiers:
+                                                  type: object
+                                                  example:
+                                                    id: 1236
+                                                  description: |
+                                                    Identifiers attached with the associated object record. It can be ext_id or id.
+                                                    NOTE:
+                                                    - Either ext_id or id is required, if both are not provided, then error will be returned.
+                                                    - Both ext_id and id cannot be provided in the same request.
+                                                  properties:
+                                                    ext_id:
+                                                      type: string
+                                                      description: ext_id is ID of record in the external system that client want to store in the object system.
+                                                      example: 9ab4c8d2ef
+                                                    id:
+                                                      type: integer
+                                                      description: Internal ID of the object record generated by Brevo
+                                            - type: object
+                                              properties:
+                                                identifiers:
+                                                  type: object
+                                                  example:
+                                                    ext_id: f7e8d9c0ba
+              required:
+                - records
+      responses:
+        "202":
+          description: Batch request accepted for processing of upsert object records.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  processId:
+                    type: integer
+                    format: int64
+                    description: Unique Id for the batch process used to track the status of the batch.
+                    example: 21
+                  message:
+                    type: string
+                    example: "Batch object records are being processed"
+        "400":
+          description: Bad request (e.g., invalid organization ID, invalid object_type, records cannot be empty or more than 1000)
+        "404":
+          description: Object not found for the provided organization or object type
+        "403":
+          description: Custom objects are not available on this account.
+        "500":
+          description: Internal server error
+  /objects/{object_type}/records:
+    get:
+      tags:
+        - Custom Objects
+      summary: Get the list of object records and total records count for an object.
+      description: |
+            This API retrieves a list of object records along with their associated records and provides the total count of records for the specified object.
+
+            **Note**:
+            Contact as object type is not supported in this endpoint.
+      operationId: getrecords
+      parameters:
+        - name: object_type
+          in: path
+          description: 'object type for the attribute'
+          required: true
+          schema:
+            type: string
+            example: vehicle
+        - name: limit
+          in: query
+          description: Number of records returned per page
+          required: true
+          schema:
+            maximum: 1000
+            minimum: 0
+            type: integer
+            format: int64
+        - name: page_num
+          in: query
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+          required: true
+          description: Page number for pagination. It's used to fetch the object records on a provided page number. Must be a valid positive integer.
+        - name: sort
+          in: query
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: Sort order, must be 'asc' or 'desc'. Default to 'desc' if not provided.
+        - name: association
+          in: query
+          schema:
+            type: string
+            enum: [true, false]
+          description: Whether to include associations, must be 'true' or 'false'. Default to 'false' if not provided.
+      responses:
+        "200":
+          description: A list of object records for an object type. If association param is set true it will return 5 associated records per association for an object type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                    format: int64
+                    description: Total number of object records for an object type.
+                    example: 350
+                  records:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        createdAt:
+                          type: string
+                          format: date-time
+                          description: Timestamp when the object record was created
+                          example: 2025-07-22T10:20:30Z
+                        updatedAt:
+                          type: string
+                          format: date-time
+                          example: 2025-07-22T10:20:30Z
+                          description: Timestamp when the object record was last updated
+                        identifiers:
+                          type: object
+                          description: |
+                            Identifiers attached with the object record. It can have id or ext_id. ext_id is ID of record in the external system that client want to store in the object system, id is an internal ID of object record generated by Brevo system.
+                          properties:
+                            id:
+                              type: integer
+                              description: Internal ID of the object record generated by Brevo
+                              example: 16789
+                            ext_id:
+                              type: string
+                              description: ext_id is ID of record in the external system that client want to store in the object system.
+                              example: "507f1f77bc"
+                        attributes:
+                          type: object
+                          description: |
+                            Attributes attached with the object record. Only the already created attributes will be used with records.
+                            Minimum 1 attribute is required.
+                          example:
+                            make: "Toyoto"
+                            model: "Corolla"
+                            color: "Black"
+                            year: 2020
+                            engine_type: "Hybrid"
+                        associations:
+                          type: array
+                          description: List of associations for the object record. If association query param is true it will return 5 associated records per association.
+                          items:
+                            oneOf:
+                            - type: object
+                              properties:
+                                object_type:
+                                  type: string
+                                  description: Type of the associated object
+                                  example: garage
+                                records:
+                                  type: array
+                                  items:
+                                    oneOf:
+                                      - type: object
+                                        properties:
+                                          identifiers:
+                                            description: Identifiers attached with the associated object record.
+                                            type: object
+                                            properties:
+                                              id:
+                                                type: integer
+                                                description: Internal ID of the object record generated by Brevo
+                                                example: 12345
+                                      - type: object
+                                        properties:
+                                          identifiers:
+                                            description: Identifiers attached with the associated object record.
+                                            type: object
+                                            properties:
+                                              id:
+                                                type: integer
+                                                description: Internal ID of the object record generated by Brevo
+                                                example: 45678
+                            - type: object
+                              properties:
+                                object_type:
+                                  type: string
+                                  description: Type of the associated object
+                                  example: insurance
+                                records:
+                                  type: array
+                                  items:
+                                    oneOf:
+                                      - type: object
+                                        properties:
+                                          identifiers:
+                                            description: Identifiers attached with the associated object record. Only includes the internal ID.
+                                            type: object
+                                            properties:
+                                              id:
+                                                type: integer
+                                                description: Internal ID of the insurance object record generated by Brevo
+                                                example: 98765
+                                      - type: object
+                                        properties:
+                                          identifiers:
+                                            description: Identifiers attached with the associated object record. Only includes the internal ID.
+                                            type: object
+                                            properties:
+                                              id:
+                                                type: integer
+                                                description: Internal ID of the insurance object record generated by Brevo
+                                                example: 87654
+
+
+        "400":
+          description: Bad request (e.g., invalid object_type, invalid page number provided)
+        "403":
+          description: Custom objects are not available on this account.
+        "424":
+          description: primary attribute not found
+        "500":
+          description: Internal server error
+  /smsCampaigns:
+    get:
+      tags:
+          - SMS Campaigns
+      summary: Returns the information for all your created SMS campaigns
+      operationId: getSmsCampaigns
+      parameters:
+        - name: status
+          description: Status of campaign.
+          in: query
+          required: false
+          type: string
+          enum:
+            - suspended
+            - archive
+            - sent
+            - queued
+            - draft
+            - inProcess
+        - name: startDate
+          description: Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent sms campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
+          in: query
+          required: false
+          type: string
+        - name: limit
+          description: Number limitation for the result returned
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 500
+          maximum: 1000
+          minimum: 0
+        - name: offset
+          description: Beginning point in the list to retrieve from.
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 0
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+          '200':
+            description: SMS campaigns informations
+            schema:
+              $ref: '#/definitions/getSmsCampaigns'
+            examples:
+                application/json:
+                    {
+                      "campaigns": [
+                        {
+                          "id": 2,
+                          "name": "PROMO CODE",
+                          "status": "sent",
+                          "content": "Visit our Store and get some discount !",
+                          "scheduledAt": "2017-06-01T12:30:00Z",
+                          "testSent": true,
+                          "sender": "MyCompany",
+                          "createdAt": "2017-06-01T12:30:00Z",
+                          "modifiedAt": "2017-05-01T12:30:00Z",
+                          "sentDate": "2017-06-01T12:30:00Z",
+                          "recipients": {
+                            "lists": [
+                              21
+                            ],
+                            "exclusionLists": [
+                              13
+                            ]
+                          },
+                          "statistics": {
+                            "delivered": 2987,
+                            "sent": 3000,
+                            "processing": 0,
+                            "softBounces": 3,
+                            "hardBounces": 1,
+                            "unsubscriptions": 3,
+                            "answered": 2
+                          }
+                        },
+                        {
+                          "id": 10,
+                          "name": "SUMMER SALE",
+                          "status": "draft",
+                          "content": "Summer Sale is starting tomorrow. Get extra 10% with this code:SUM17",
+                          "scheduledAt": "2017-08-04T12:30:00Z",
+                          "testSent": false,
+                          "sender": "MyCompany",
+                          "createdAt": "2017-06-01T12:30:00Z",
+                          "modifiedAt": "2017-05-01T12:30:00Z",
+                          "sentDate": "2017-06-01T12:30:00Z",
+                          "recipients": {
+                            "lists": [
+                              21
+                            ],
+                            "exclusionLists": [
+                              13
+                            ]
+                          },
+                          "statistics": {
+                            "delivered": 2987,
+                            "sent": 3000,
+                            "processing": 0,
+                            "softBounces": 3,
+                            "hardBounces": 1,
+                            "unsubscriptions": 3,
+                            "answered": 2
+                          }
+                        }
+                      ],
+                      "count": 12
+                    }
+          '400':
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+    post:
+      tags:
+          - SMS Campaigns
+      summary: Creates an SMS campaign
+      operationId: createSmsCampaign
+      parameters:
+        - name: createSmsCampaign
+          description: Values to create an SMS Campaign
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/createSmsCampaign'
+      responses:
+        '201':
+          description: SMS campaign created
+          schema:
+            $ref: '#/definitions/createModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smsCampaigns/{campaignId}:
+    get:
+      tags:
+          - SMS Campaigns
+      summary: Get an SMS campaign
+      operationId: getSmsCampaign
+      parameters:
+        - name: campaignId
+          description: id of the SMS campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '200':
+          description: SMS campaign informations
+          schema:
+            $ref: '#/definitions/getSmsCampaign'
+          examples:
+            application/json:
+                {
+                  "id": 2,
+                  "name": "PROMO CODE",
+                  "status": "sent",
+                  "content": "Visit our Store and get some discount !",
+                  "scheduledAt": "2017-06-01T12:30:00Z",
+                  "testSent": true,
+                  "sender": "MyCompany",
+                  "createdAt": "2017-06-01T12:30:00Z",
+                  "modifiedAt": "2017-05-01T12:30:00Z",
+                  "recipients": {
+                    "lists": [
+                      21
+                    ],
+                    "exclusionLists": [
+                      13
+                    ]
+                  },
+                  "statistics": {
+                    "delivered": 2987,
+                    "sent": 3000,
+                    "processing": 0,
+                    "softBounces": 3,
+                    "hardBounces": 1,
+                    "unsubscriptions": 3,
+                    "answered": 2
+                  }
+                }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+          - SMS Campaigns
+      summary: Update an SMS campaign
+      operationId: updateSmsCampaign
+      parameters:
+        - name: campaignId
+          description: id of the SMS campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: updateSmsCampaign
+          description: Values to update an SMS Campaign
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/updateSmsCampaign'
+      responses:
+        '204':
+          description: SMS campaign updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+          - SMS Campaigns
+      summary: Delete an SMS campaign
+      operationId: deleteSmsCampaign
+      parameters:
+        - name: campaignId
+          description: id of the SMS campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '204':
+          description: SMS campaign has been deleted
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smsCampaigns/{campaignId}/sendNow:
+    post:
+      tags:
+          - SMS Campaigns
+      summary: Send your SMS campaign immediately
+      operationId: sendSmsCampaignNow
+      parameters:
+        - name: campaignId
+          description: id of the campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '204':
+          description: SMS campaign has been scheduled
+        '400':
+          description: SMS Campaign could not be sent
+          schema:
+            $ref: '#/definitions/errorModel'
+        '402':
+          description: You don't have enough credit to send your campaign. Please update your plan
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smsCampaigns/{campaignId}/status:
+    put:
+      tags:
+          - SMS Campaigns
+      summary: Update a campaign's status
+      operationId: updateSmsCampaignStatus
+      parameters:
+        - name: campaignId
+          description: id of the campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: status
+          description: Status of the campaign.
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/updateCampaignStatus'
+      responses:
+        '204':
+          description: The campaign status has been updated successfully
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smsCampaigns/{campaignId}/sendTest:
+    post:
+      tags:
+          - SMS Campaigns
+      summary: Send a test SMS campaign
+      operationId: sendTestSms
+      parameters:
+      - name: campaignId
+        description: Id of the SMS campaign
+        in: path
+        type: integer
+        format: int64
+        required: true
+      - name: phoneNumber
+        description: Mobile number of the recipient with the country code. This number must belong to one of your contacts in Brevo account and must not be blacklisted
+        in: body
+        required: true
+        schema:
+            $ref: '#/definitions/sendTestSms'
+      responses:
+        '204':
+          description: Test SMS has been sent successfully to the recipient
+        '400':
+          description: Test SMS could not be sent to the following email addresses
+          schema:
+            $ref: '#/definitions/postSendSmsTestFailed'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smsCampaigns/{campaignId}/exportRecipients:
+    post:
+      tags:
+          - SMS Campaigns
+      summary: Export an SMS campaign's recipients
+      description: It returns the background process ID which on completion calls the notify URL that you have set in the input.
+      operationId: requestSmsRecipientExport
+      parameters:
+        - name: campaignId
+          description: id of the campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: recipientExport
+          description: Values to send for a recipient export request
+          in: body
+          required: false
+          schema:
+            $ref: '#/definitions/requestSmsRecipientExport'
+      responses:
+        '202':
+          description: Recipient export request has been accepted
+          schema:
+            $ref: '#/definitions/createdProcessId'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /smsCampaigns/{campaignId}/sendReport:
+    post:
+      tags:
+          - SMS Campaigns
+      summary: Send an SMS campaign's report
+      description:  Send report of Sent and Archived campaign, to the specified email addresses, with respective data and a pdf attachment in detail.
+      operationId: sendSmsReport
+      parameters:
+      - name: campaignId
+        description: id of the campaign
+        in: path
+        type: integer
+        format: int64
+        required: true
+      - name: sendReport
+        description: Values for send a report
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/sendReport'
+      responses:
+        '204':
+          description: Report has been successfully sent to the defined recipients
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /transactionalSMS/send:
+    post:
+      tags:
+      - Transactional SMS
+      summary: Send SMS message asynchronously to a mobile number
+      operationId: sendAsyncTransactionalSms
+      requestBody:
+        description: Values to send a transactional SMS
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/sendTransacSms'
+        required: true
+      responses:
+        201:
+          description: SMS has been sent successfully to the recipient
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/sendSmsAsync'
+        400:
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorModel'
+  /transactionalSMS/sms:
+    post:
+      tags:
+          - Transactional SMS
+      summary: Send SMS message to a mobile number
+      operationId: sendTransacSms
+      parameters:
+        - name: sendTransacSms
+          description: Values to send a transactional SMS
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/sendTransacSms'
+      responses:
+        '201':
+          description: SMS has been sent successfully to the recipient
+          schema:
+            $ref: '#/definitions/sendSms'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '402':
+          description: You don't have enough credit to send your SMS. Please update your plan
+          schema:
+            $ref: '#/definitions/errorModel'
+  /transactionalSMS/statistics/aggregatedReport:
+    get:
+      tags:
+          - Transactional SMS
+      summary: Get your SMS activity aggregated over a period of time
+      operationId: getTransacAggregatedSmsReport
+      parameters:
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the report
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report
+          in: query
+          required: false
+          type: string
+        - name: days
+          description: Number of days in the past including today (positive integer). Not compatible with startDate and endDate
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: tag
+          description: Filter on a tag
+          in: query
+          required: false
+          type: string
+      responses:
+        '200':
+          description: Aggregated SMS report informations
+          schema:
+            $ref: '#/definitions/getTransacAggregatedSmsReport'
+          examples:
+            application/json:
+              {
+                "range": "2015-05-22|2017-11-29",
+                "requests": 54,
+                "delivered": 16,
+                "hardBounces": 5,
+                "softBounces": 26,
+                "blocked": 4,
+                "unsubscribed": 10,
+                "replied": 8,
+                "accepted": 6,
+                "rejected": 14,
+                "skipped": 3
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /transactionalSMS/statistics/reports:
+    get:
+      tags:
+          - Transactional SMS
+      summary: Get your SMS activity aggregated per day
+      operationId: getTransacSmsReport
+      parameters:
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the report
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report
+          in: query
+          required: false
+          type: string
+        - name: days
+          description: Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: tag
+          description: Filter on a tag
+          in: query
+          required: false
+          type: string
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: Aggregated SMS report informations
+          schema:
+            $ref: '#/definitions/getTransacSmsReport'
+          examples:
+            application/json:
+              { "reports": [
+                  {
+                    "date":"2017-04-30",
+                    "requests":10756,
+                    "delivered":10103,
+                    "hardBounces":21,
+                    "softBounces":137,
+                    "blocked":1026,
+                    "unsubscribed":720,
+                    "replied":5091,
+                    "accepted":2318,
+                    "rejected":0,
+                    "skipped":1
+                  },
+                  {
+                    "date":"2017-05-01",
+                    "requests":18812,
+                    "delivered":17499,
+                    "hardBounces":34,
+                    "softBounces":254,
+                    "blocked":1514,
+                    "unsubscribed":1090,
+                    "replied":10089,
+                    "accepted":4393,
+                    "rejected":0,
+                    "skipped":0
+                  },
+                  {
+                    "date":"2017-05-02",
+                    "requests":14321,
+                    "delivered":13427,
+                    "hardBounces":16,
+                    "softBounces":176,
+                    "blocked":1646,
+                    "unsubscribed":1170,
+                    "replied":11563,
+                    "accepted":4689,
+                    "rejected":0,
+                    "skipped":1
+                  }
+                ]
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /transactionalSMS/statistics/events:
+    get:
+      tags:
+          - Transactional SMS
+      summary: Get all your SMS activity (unaggregated events)
+      operationId: getSmsEvents
+      parameters:
+        - name: limit
+          description: Number of documents per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 50
+          maximum : 100
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date (YYYY-MM-DD) of the report
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date (YYYY-MM-DD) of the report
+          in: query
+          required: false
+          type: string
+        - name: offset
+          description: Index of the first document of the page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 0
+        - name: days
+          description: Number of days in the past including today (positive integer). Not compatible with 'startDate' and 'endDate'
+          in: query
+          required: false
+          type: integer
+          format: int64
+        - name: phoneNumber
+          description: Filter the report for a specific phone number
+          in: query
+          required: false
+          type: string
+        - name: event
+          description: Filter the report for specific events
+          in: query
+          required: false
+          type: string
+          enum:
+           - bounces
+           - hardBounces
+           - softBounces
+           - delivered
+           - sent
+           - accepted
+           - unsubscription
+           - replies
+           - blocked
+           - rejected
+           - skipped
+        - name: tags
+          description: Filter the report for specific tags passed as a serialized urlencoded array
+          in: query
+          required: false
+          type: string
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: Sms events report informations
+          schema:
+            $ref: '#/definitions/getSmsEventReport'
+          examples:
+            application/json:
+                {
+                  "events": [
+                    {
+                      "phoneNumber": "00911059469013",
+                      "date": "2015-05-20T12:30:00Z",
+                      "messageId": "1473139351170140",
+                      "event": "sent",
+                      "reason": "Recipient is currently unreachable",
+                      "tag": "cabWaiting"
+                    },
+                    {
+                      "phoneNumber": "00911059469013",
+                      "date": "2015-05-20T16:30:00Z",
+                      "messageId": "1473139351170140",
+                      "event": "delivered",
+                      "reason": "Recipient is currently unreachable",
+                      "tag": "cabRequest"
+                    },
+                  ]
+                }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /whatsappCampaigns/{campaignId}:
+    get:
+      tags:
+      - WhatsApp Campaigns
+      summary: Get a WhatsApp campaign
+      operationId: getWhatsAppCampaign
+      parameters:
+      - name: campaignId
+        in: path
+        description: Id of the campaign
+        required: true
+        type: integer
+        format: int64
+      responses:
+        200:
+          description: Get WhatsApp campaign information on the basis of campaignId
+          schema:
+                $ref: '#/definitions/getWhatsappCampaignOverview'
+          examples:
+            application/json:
+              response:
+                value:
+                  id: 1672035851100690
+                  campaignName: Test WhatsApp Campaign
+                  campaignStatus: sent
+                  scheduledAt: 2022-12-26T09:50:00Z
+                  senderNumber: 9368207029
+                  recipients:
+                  type: list
+                  includedLists:
+                  - 22
+                  excludedLists:
+                  - 45
+                  template :
+                    name : "official_campaign8"
+                    category: "MARKETING"
+                    language: "en"
+                    contains_button : true
+                    display_header : false
+                    components :
+                      - type : "BODY"
+                        text : "making it look like readable English."
+                      - type: "BUTTONS"
+                        buttons :
+                          - type: "URL"
+                            text: "vLorem Ipsum is simply du"
+                            url : "app.brevo"
+                          - type: "PHONE_NUMBER"
+                            text: "Lorem Ipsum is simply dum"
+                            phone_number: "+918800613137"
+                    header_variables :
+                      - name:  "FIRSTNAME"
+                        default: "INVALID HEADER"
+                        index: 1
+                        datatype: "text"
+                    header_type : "text"
+                    body_variable: []
+                    button_type : "CALL_TO_ACTION"
+                    header_footer: true
+                  stats:
+                    sent: 3,
+                    delivered: 3,
+                    read: 2,
+                    unsubscribe: 0,
+                    not_sent: 4
+                  createdAt: 2022-12-26T06:50:00Z
+                  modifiedAt: 2022-12-26T08:50:00Z
+        400:
+          description: bad request
+          schema:
+                $ref: '#/definitions/errorModel'
+        404:
+          description: Campaign Id not found
+          schema:
+                $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+      - WhatsApp Campaigns
+      summary: Delete a WhatsApp campaign
+      operationId: deleteWhatsAppCampaign
+      parameters:
+      - name: campaignId
+        in: path
+        description: id of the campaign
+        required: true
+        type: integer
+        format: int64
+      responses:
+        204:
+          description: WhatsApp campaign has been deleted
+        400:
+          description: bad request
+          schema:
+                $ref: '#/definitions/errorModel'
+        404:
+          description: Campaign Id not found
+          schema:
+                $ref: '#/definitions/errorModel'
+    put:
+      tags:
+      - WhatsApp Campaigns
+      summary: Update a WhatsApp campaign
+      operationId: updateWhatsAppCampaign
+      parameters:
+        - name: campaignId
+          description: Id of the campaign
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: whatsAppCampaign
+          description: values to update WhatsApp Campaign
+          in: body
+          schema:
+            $ref: '#/definitions/updateWhatsAppCampaign'
+      responses:
+        '204':
+          description: WhatsApp Campaign has been updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Campaign id not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /whatsappCampaigns/template-list:
+    get:
+      tags:
+      - WhatsApp Campaigns
+      summary: Return all your created WhatsApp templates
+      operationId: getWhatsAppTemplates
+      parameters:
+      - name: startDate
+        in: query
+        description: |
+          **Mandatory if endDate is used**. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the templates created.
+          **Prefer to pass your timezone in date-time format for accurate result**
+        type: string
+      - name: endDate
+        in: query
+        description: |
+          **Mandatory if startDate is used**. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the templates created.
+          **Prefer to pass your timezone in date-time format for accurate result**
+        type: string
+      - name: limit
+        in: query
+        description: Number of documents per page
+        maximum: 100
+        minimum: 0
+        type: integer
+        format: int64
+        default: 50
+      - name: offset
+        in: query
+        description: Index of the first document in the page
+        type: integer
+        format: int64
+        default: 0
+      - name: sort
+        in: query
+        description: Sort the results in the ascending/descending order of record modification. Default order is **descending** if `sort` is not passed
+        required: false
+        type: string
+        default: desc
+        enum:
+          - asc
+          - desc
+      - name: source
+        in : query
+        description:  source of the template
+        required: false
+        type: string
+        enum:
+          - Automation
+          - Conversations
+      responses:
+        200:
+          description: WhatsApp templates informations
+          schema:
+              $ref: '#/definitions/getWATemplates'
+          examples:
+            application/json:
+              response:
+                value:
+                  count: 2
+                  templates:
+                    - id: 235
+                      name: campaign_22
+                      type: whatsapp
+                      status: approved
+                      language: en
+                      category: 'MARKETING'
+                      errorReason: 'NONE'
+                      createdAt: 2017-05-01T12:30:00Z
+                      modifiedAt: 2017-05-01T12:30:00Z
+                    - id: 124
+                      name: test-template
+                      type: whatsapp
+                      status: draft
+                      language: ''
+                      category: 'MARKETING'
+                      errorReason: 'NONE'
+                      createdAt: 2017-0
+                      modifiedAt: 2017-05-01T12:30:00Z
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /whatsappCampaigns :
+    post:
+      tags:
+      - WhatsApp Campaigns
+      summary : Create and Send a WhatsApp campaign
+      operationId : createWhatsAppCampaign
+      parameters:
+        - name: whatsAppCampaigns
+          description: Values to create a campaign
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/createWhatsAppCampaign'
+      responses:
+          '201':
+            description: WhatsApp campaign created
+            schema:
+              $ref: '#/definitions/createModel'
+          '400':
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+    get :
+      tags:
+      - WhatsApp Campaigns
+      summary: Return all your created WhatsApp campaigns
+      operationId: getWhatsAppCampaigns
+      parameters:
+      - name: startDate
+        in: query
+        description: |
+          **Mandatory if endDate is used**. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the campaigns created.
+          **Prefer to pass your timezone in date-time format for accurate result**
+        type: string
+      - name : endDate
+        in : query
+        description : |
+          **Mandatory if startDate is used**. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the campaigns created.
+          **Prefer to pass your timezone in date-time format for accurate result**
+        type : string
+      - name: limit
+        in: query
+        description: Number of documents per page
+        maximum: 100
+        minimum: 0
+        type: integer
+        format: int64
+        default: 50
+      - name: offset
+        in: query
+        description: Index of the first document in the page
+        type: integer
+        format: int64
+        default: 0
+      - name: sort
+        in: query
+        description: Sort the results in the ascending/descending order of record modification. Default order is **descending** if `sort` is not passed
+        required: false
+        type: string
+        default: desc
+        enum:
+          - asc
+          - desc
+      responses:
+        200:
+          description: WhatsApp campaigns informations
+          schema:
+                $ref: '#/definitions/getWhatsappCampaigns'
+          examples:
+            application/json:
+                  count: 23
+                  campaigns:
+                      - id: 1672035851100690
+                        campaignName: campaign_22
+                        campaignStatus: sent
+                        templateId : 637660278078655
+                        scheduledAt: 2022-12-27T09:50:00Z
+                        errorReason : NONE
+                        name: campaign_22
+                        type: whatsapp
+                        status: approved
+                        language: en
+                        category: 'MARKETING'
+                        invalidatedContacts : 0
+                        stats :
+                          sent : 3
+                          delivered: 3
+                          read : 2
+                          unsubscribe : 0
+                          notSent : 4
+                        readPercentage : 28.57
+                        createdAt: 2017-05-01T12:30:00Z
+                        modifiedAt: 2017-05-01T12:30:00Z
+        400:
+          description: bad request
+          schema:
+                $ref: '#/definitions/errorModel'
+  /whatsppCampaigns/template :
+    post:
+      tags:
+      - WhatsApp Campaigns
+      summary : Create a WhatsApp template
+      operationId: createWhatsAppTemplate
+      parameters:
+        - name : whatsAppTemplates
+          description : Values to create a template
+          required: true
+          in : body
+          schema:
+            $ref : '#/definitions/createWhatsAppTemplate'
+      responses:
+          '201':
+            description: WhatsApp campaign created
+            schema:
+              $ref: '#/definitions/createModel'
+          '400':
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+  /whatsappCampaigns/template/approval/{templateId} :
+    post:
+      tags :
+      - WhatsApp Campaigns
+      summary : Send your WhatsApp template for approval
+      operationId : sendWhatsAppTemplateApproval
+      parameters :
+      - name : templateId
+        in: path
+        description: id of the campaign
+        required: true
+        type: integer
+        format: int64
+      responses :
+        '200':
+          description: WhatsApp template sent for approval
+        '400':
+          description: bad request
+          schema:
+                $ref: '#/definitions/errorModel'
+  /whatsappCampaigns/config :
+    get:
+      tags:
+      - WhatsApp Campaigns
+      summary: Get your WhatsApp API account information
+      operationId: getWhatsAppConfig
+      responses:
+        200:
+          description: Get all the information of your WhatsApp API account
+          schema:
+                $ref: '#/definitions/getWhatsAppConfig'
+          examples:
+            application/json :
+                    whatsappBusinessAccountID : 105569359072383
+                    sendingLimit : TIER_1K
+                    phoneNumberQuality : GREEN
+                    whatsappBusinessAccountStatus : APPROVED
+                    businessStatus : verified
+                    phoneNumberNameStatus : APPROVED
+        400:
+          description: bad request
+          schema:
+                $ref: '#/definitions/errorModel'
+  /loyalty/config/programs:
+    get:
+      tags:
+        - Program
+      summary: Get loyalty program list
+      description: Returns list of loyalty programs
+      operationId: getLPList
+      parameters:
+        - description: Number of documents per page
+          in: query
+          name: limit
+          type: integer
+        - description: Index of the first document in the page
+          in: query
+          name: offset
+          type: integer
+        - description: Sort documents by field
+          enum:
+          - name
+          - created_at
+          - updated_at
+          in: query
+          name: sort_field
+          type: string
+        - description: Sort the documents in the ascending or descending order
+          in: query
+          name: sort
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully retrieved loyalty program page.
+          schema:
+            $ref: '#/definitions/loyaltyProgramPage'
+        "400":
+          description: Invalid sort_field parameter value
+          schema:
+            type: string
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: Loyalty program not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+    post:
+      tags:
+        - Program
+      summary: Create loyalty program
+      description: Creates loyalty program
+      operationId: createNewLP
+      parameters:
+        - description: Create Loyalty Program Payload
+          in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/createLoyaltyProgramPayload'
+      responses:
+        "200":
+          description: Successfully created loyalty program
+          schema:
+            $ref: '#/definitions/loyaltyProgram'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "409":
+          description: Loyalty program name already exists
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/config/programs/{pid}:
+    get:
+      tags:
+        - Program
+      summary: Get loyalty program Info
+      description: Returns loyalty program
+      operationId: getLoyaltyProgramInfo
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Successfully retrieved loyalty program
+          schema:
+            $ref: '#/definitions/loyaltyProgram'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: Loyalty program not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+    put:
+      tags:
+        - Program
+      summary: Update loyalty program
+      description: Updates loyalty program
+      operationId: updateLoyaltyProgram
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Update Loyalty Program Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/updateLoyaltyProgramPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully updated loyalty program
+          schema:
+            $ref: '#/definitions/loyaltyProgram'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: Loyalty program not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "409":
+          description: Loyalty program name already exists
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+    patch:
+      tags:
+        - Program
+      summary: Partially update loyalty program
+      description: Partially updates loyalty program
+      operationId: partiallyUpdateLoyaltyProgram
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Loyalty Program Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/patchLoyaltyProgramPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully retrieved loyalty program
+          schema:
+            $ref: '#/definitions/loyaltyProgram'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: Loyalty program not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "409":
+          description: Loyalty program name already exists
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+    delete:
+      tags:
+        - Program
+      summary: Delete Loyalty Program
+      description: Deletes Loyalty Program
+      operationId: deleteLoyaltyProgram
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Successfully deleted loyalty program
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: Loyalty program not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/config/programs/{pid}/publish:
+    post:
+      tags:
+          - Program
+      summary: Publish loyalty program
+      description: Publishes loyalty program
+      operationId: publishLoyaltyProgram
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully published loyalty program
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: Loyalty program not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/config/programs/{pid}/subscriptions:
+    post:
+      tags:
+        - Program
+      summary: Create subscription
+      description: Subscribes to a loyalty program
+      operationId: subscribeToLoyaltyProgram
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Create Subscription Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/createSubscriptionPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully  created subscription
+          schema:
+            $ref: '#/definitions/subscription'
+        "400":
+          description: loyalty subscription id is already assigned to a contact
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: invalid contact id
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/config/programs/{pid}/subscription-members:
+    post:
+      tags:
+        - Program
+      summary: Create subscription member
+      description: Add member to a subscription
+      operationId: subscribeMemberToASubscription
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Add Subscription Member Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/addSubscriptionMemberPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully added subscription member
+          schema:
+            $ref: '#/definitions/subscriptionMember'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: cannot validate loyalty program and organization id
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "409":
+          description: Owner contact cannot be added as member
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+    delete:
+      tags:
+        - Program
+      summary: Delete subscription member
+      description: Deletes member from a subscription
+      operationId: deleteContactMembers
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Member Contact Ids
+        format: string
+        in: query
+        name: memberContactIds
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Successfully deleted subscription member
+        "400":
+          description: Missing memberContactIds
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: Contact subscription not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/config/programs/{pid}/account-info:
+    get:
+      tags:
+        - Program
+      summary: Get Subscription Data
+      description: Get Information of balances, tiers, rewards and subscription members for a subscription
+      operationId: getParameterSubscriptionInfo
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Contact Id
+        in: query
+        name: contactId
+        type: string
+      - description: Filter List
+        in: query
+        name: params
+        type: string
+      - description: Loyalty Subscription Id
+        in: query
+        name: loyaltySubscriptionId
+        type: string
+      - description: Include balances tied to internal definitions.
+        in: query
+        name: includeInternal
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully retrieved subscription info
+          schema:
+            $ref: '#/definitions/subscriptionHandlerInfo'
+        "400":
+          description: either contact id or loyalty subscription id is invalid
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+  # Offer
+  /loyalty/offer/programs/{pid}/code-pools/{cpid}/codes-count:
+    get:
+      tags:
+        - Reward
+      summary: Get code count
+      description: Get code count
+      operationId: getCodeCount
+      parameters:
+      - description: Loyalty Program ID
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Code Pool ID
+        format: uuid
+        in: path
+        name: cpid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Code count successfully fetched
+          schema:
+            $ref: '#/definitions/main.codeCountHttpResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+  /loyalty/offer/programs/{pid}/vouchers:
+    get:
+      consumes:
+      - application/json
+      description: Get voucher for a contact
+      parameters:
+        - description: Loyalty Program ID
+          format: uuid
+          in: path
+          name: pid
+          required: true
+          type: string
+        - default: 25
+          description: Page size
+          in: query
+          maximum: 100
+          minimum: 1
+          name: limit
+          type: integer
+        - default: 0
+          description: Pagination offset
+          in: query
+          minimum: 0
+          name: offset
+          type: integer
+        - default: desc
+          description: Sort order
+          in: query
+          name: sort
+          type: string
+          enum:
+            - asc
+            - desc
+        - default: updatedAt
+          description: Sort field
+          in: query
+          name: sortField
+          type: string
+          enum:
+            - updatedAt
+            - createdAt
+        - description: Contact ID
+          in: query
+          minimum: 1
+          name: contactId
+          required: true
+          type: integer
+        - description: Metadata value for a Key filter
+          in: query
+          name: metadata[key][value]
+          type: string
+        - description: Reward ID
+          in: query
+          name: rewardId
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Voucher list successfully retrieved
+          schema:
+            $ref: '#/definitions/main.modelContactRewardsResp'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+      summary: Get voucher for a contact
+      tags:
+      - Reward
+  /loyalty/offer/programs/{pid}/offers:
+    get:
+      consumes:
+      - application/json
+      description: Returns a reward page
+      parameters:
+      - description: Loyalty Program ID
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - default: 25
+        description: Page size
+        in: query
+        name: limit
+        type: integer
+        maximum: 100
+        minimum: 1
+      - default: 0
+        description: Pagination offset
+        in: query
+        name: offset
+        type: integer
+      - description: State of the reward
+        default: all
+        in: query
+        name: state
+        type: string
+      - description: Version
+        in: query
+        name: version
+        type: string
+        default: draft
+        enum:
+          - active
+          - draft
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Reward list successfully retrieved
+          schema:
+            $ref: '#/definitions/main.rewardPage'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "424":
+          description: Failed Dependency
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+      summary: Get Reward Page API
+      tags:
+      - Reward
+    post:
+      consumes:
+      - application/json
+      description: Creates a new reward in loyalty program.
+      parameters:
+      - description: Loyalty Program ID
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Reward creation payload
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/main.createRewardPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Reward successfully created
+          schema:
+            $ref: '#/definitions/main.createRewardResponse'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+      summary: Create a reward
+      tags:
+      - Reward
+  /loyalty/offer/programs/{pid}/rewards/{rid}:
+    get:
+      consumes:
+      - application/json
+      description: Returns reward information.
+      parameters:
+      - description: Loyalty Program ID
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Reward ID
+        format: uuid
+        in: path
+        name: rid
+        required: true
+        type: string
+      - description: Version
+        in: query
+        name: version
+        type: string
+        enum:
+          - active
+          - draft
+        default: draft
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful retrieval of reward data
+          schema:
+            $ref: '#/definitions/main.reward'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "424":
+          description: Failed Dependency
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+      summary: Get reward information
+      tags:
+      - Reward
+  /loyalty/offer/programs/{pid}/rewards/attribute:
+    post:
+      consumes:
+      - application/json
+      description: Create a voucher and attribute it to a specific membership.
+      parameters:
+      - description: Loyalty Program ID
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Voucher creation payload
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/main.attributeRewardPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Voucher successfully created
+          schema:
+            $ref: '#/definitions/main.rewardAttribution'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+      summary: Create a voucher
+      tags:
+      - Reward
+  /loyalty/offer/programs/{pid}/rewards/redeem:
+    post:
+      consumes:
+      - application/json
+      description: Creates a request to redeem a voucher.
+      parameters:
+      - description: Loyalty Program ID
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Redeem transaction creation payload
+        in: body
+        name: payload
+        required: true
+        schema:
+          $ref: '#/definitions/main.createRedeemPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Redeem request successfully created
+          schema:
+            $ref: '#/definitions/main.redeem'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "412":
+          description: Precondition Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "417":
+          description: Expectation Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+      summary: Create redeem voucher request
+      tags:
+       - Reward
+  /loyalty/offer/programs/{pid}/rewards/redeem/{tid}/complete:
+    post:
+      consumes:
+      - application/json
+      description: Completes voucher redeem request.
+      parameters:
+      - description: Loyalty Program ID
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Redeem transaction ID
+        in: path
+        name: tid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Voucher Redeem completed
+          schema:
+            $ref: '#/definitions/main.redeem'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "412":
+          description: Precondition Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "417":
+          description: Expectation Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+
+      summary: Complete redeem voucher request
+      tags:
+      - Reward
+  /loyalty/offer/programs/{pid}/rewards/revoke:
+    delete:
+      consumes:
+      - application/json
+      description: Revoke attributed vouchers.
+      parameters:
+      - description: Loyalty Program ID
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - name: attributedRewardIds
+        in: query
+        description: Reward Attribution IDs (comma seperated)
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Successful revocation of voucher
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+      summary: Revoke vouchers
+      tags:
+      - Reward
+  /loyalty/offer/programs/{pid}/rewards/validate:
+    post:
+      consumes:
+      - application/json
+      description: Validates a reward.
+      parameters:
+      - description: Loyalty Program ID
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Reward validation payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/main.validateRewardPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Reward successfully validated
+          schema:
+            $ref: '#/definitions/main.rewardValidate'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "424":
+          description: Failed Dependency
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/main.errorResponse'
+      summary: Validate a reward
+      tags:
+      - Reward
+  # Balance
+  /loyalty/balance/programs/{pid}/balance-definitions:
+    get:
+      tags:
+        - Balance
+      summary: Get balance definition list
+      description: Returns balance definition page
+      operationId: getBalanceDefinitionList
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - default: 200
+        description: Limit the number of records returned
+        in: query
+        maximum: 500
+        minimum: 1
+        name: limit
+        type: integer
+      - default: 0
+        description: Offset to paginate records
+        in: query
+        minimum: 0
+        name: offset
+        type: integer
+      - description: Field to sort by
+        in: query
+        name: sortField
+        type: string
+        enum: [name, created_at, updated_at]
+        default: updated_at
+      - default: desc
+        description: Sort direction
+        in: query
+        name: sort
+        type: string
+        enum: [asc, desc]
+      - description: Version
+        in: query
+        name: version
+        type: string
+        enum: [active, draft]
+        default: draft
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful retrieval of balance definition page
+          schema:
+            $ref: '#/definitions/balanceDefinitionPage'
+        "204":
+          description: No content
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+    post:
+      tags:
+        - Balance
+      summary: Create balance definition
+      description: Creates balance definition and returns information
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Create Balance Definition Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/createBalanceDefinitionPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful creation of balance definition
+          schema:
+            $ref: '#/definitions/balanceDefinition'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: No content
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+  /loyalty/balance/programs/{pid}/balance-definitions/{bdid}:
+    get:
+      tags:
+        - Balance
+      summary: Get balance definition
+      description: Returns balance definition
+      operationId: getBalanceDefinition
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Balance Definition Id
+        format: uuid
+        in: path
+        name: bdid
+        required: true
+        type: string
+      - description: Version
+        in: query
+        name: version
+        type: string
+        enum: [active, draft]
+        default: draft
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful retrieval of balance definition
+          schema:
+            $ref: '#/definitions/balanceDefinition'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+    put:
+      tags:
+        - Balance
+      summary: Update balance definition
+      description: Updates Balance definition
+      operationId: updateBalanceDefinition
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Balance Definition Id
+        format: uuid
+        in: path
+        name: bdid
+        required: true
+        type: string
+      - description: Update Balance Definition Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/updateBalanceDefinitionPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful updation of balance definition
+          schema:
+            $ref: '#/definitions/balanceDefinition'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: balance definition doesn't exist
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "424":
+          description: Failed Dependency Error
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+    delete:
+      tags:
+        - Balance
+      summary: Delete balance definition
+      description: Delete Balance definition
+      operationId: deleteBalanceDefinition
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Balance Definition Id
+        format: uuid
+        in: path
+        name: bdid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Successful deletion of balance definition
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: Not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/balance/programs/{pid}/balance-definitions/{bdid}/limits:
+    post:
+      tags:
+        - Balance
+      summary: Create balance limits
+      description: Creates balance limit and sends the created UUID along with the data
+      operationId: createBalanceLimit
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Balance Definition Id
+        format: uuid
+        in: path
+        name: bdid
+        required: true
+        type: string
+      - description: Balance Definition Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/createBalanceLimitPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful creation of balance limit
+          schema:
+            $ref: '#/definitions/balanceLimit'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "424":
+          description: Failed Dependency Error
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/balance/programs/{pid}/balance-definitions/{bdid}/limits/{blid}:
+    get:
+      tags:
+        - Balance
+      summary: Get balance limits
+      description: Fetches balance limits and send the created UUID along with the data
+      operationId: getBalanceLimit
+      parameters:
+      - description: Version
+        in: query
+        name: version
+        type: string
+        enum: [active, draft]
+        default: draft
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Balance Definition Id
+        format: uuid
+        in: path
+        name: bdid
+        required: true
+        type: string
+      - description: Balance Limit Id
+        format: uuid
+        in: path
+        name: blid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful retrieval of balance limit
+          schema:
+            $ref: '#/definitions/balanceLimit'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: balance limit not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+    delete:
+      tags:
+        - Balance
+      summary: Delete balance limit
+      description: Delete balance limit
+      operationId: deleteBalanceLimit
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Balance Definition Id
+        format: uuid
+        in: path
+        name: bdid
+        required: true
+        type: string
+      - description: Balance Limit Id
+        format: uuid
+        in: path
+        name: blid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: Successful deletion of balance definition
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+    put:
+      tags:
+        - Balance
+      summary: Updates balance limit
+      description: Updates balance limit
+      operationId: updateBalanceLimit
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Balance Definition Id
+        format: uuid
+        in: path
+        name: bdid
+        required: true
+        type: string
+      - description: Balance Limit Id
+        format: uuid
+        in: path
+        name: blid
+        required: true
+        type: string
+      - description: Balance Limits Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/updateBalanceLimitPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful updation of balance limit
+          schema:
+            $ref: '#/definitions/balanceLimit'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/balance/programs/{pid}/subscriptions/{cid}/balances:
+    get:
+      tags:
+        - Balance
+      summary: Get subscription balances
+      description: Returns subscription balances
+      operationId: getSubscriptionBalances
+      parameters:
+      - description: Contact Id
+        format: int
+        in: path
+        name: cid
+        required: true
+        type: string
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Include balances tied to internal definitions.
+        in: query
+        name: includeInternal
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful retrieval of contact balance
+          schema:
+            $ref: '#/definitions/modelSubscriptionBalanceResp'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+    post:
+      tags:
+        - Balance
+      summary: Create subscription balances
+      description: Creates a balance for a contact
+      consumes:
+      - application/json
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Contact Id
+        format: int
+        in: path
+        name: cid
+        required: true
+        type: string
+      - description: Create Balnce Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/createBalancePayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful creation of balance
+          schema:
+            $ref: '#/definitions/balance'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: No content
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/balance/programs/{pid}/contact-balances:
+    get:
+      tags:
+        - Balance
+      summary: Get balance list
+      description: Returns balance list
+      operationId: getContactBalances
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Include balances tied to internal definitions.
+        in: query
+        name: includeInternal
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful retrieval of contact balance
+          schema:
+            $ref: '#/definitions/contactBalancesResp'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: subscription data not found for some contacts
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+  /loyalty/balance/programs/{pid}/transactions:
+    post:
+      tags:
+        - Balance
+      summary: Create new transaction
+      description: Creates new transaction and returns information
+      operationId: beginTransaction
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Transaction Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/createTransactionPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Transaction information
+          schema:
+            $ref: '#/definitions/transaction'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: Transaction not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/balance/programs/{pid}/transactions/{tid}/complete:
+    post:
+      tags:
+        - Balance
+      summary: Complete transaction
+      description: Completes transaction
+      operationId: completeTransaction
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Transaction Id
+        format: uuid
+        in: path
+        name: tid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Transaction information
+          schema:
+            $ref: '#/definitions/transaction'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: transaction not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/balance/programs/{pid}/transactions/{tid}/cancel:
+    post:
+      tags:
+        - Balance
+      summary: Cancel transaction
+      description: Cancels transaction
+      operationId: cancelTransaction
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Transaction Id
+        format: uuid
+        in: path
+        name: tid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Transaction information
+          schema:
+            $ref: '#/definitions/transaction'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: transaction not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/balance/programs/{pid}/create-order:
+    post:
+      tags:
+        - Balance
+      summary: Create balance order
+      description: Returns created order
+      operationId: createBalanceOrder
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Order Payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/createOrderPayload'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful creation of order
+          schema:
+            $ref: '#/definitions/balanceOrder'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/balance/programs/{pid}/active-balance:
+    get:
+      tags:
+        - Balance
+      consumes:
+      - application/json
+      summary: Get Active Balances API
+      description: Returns Active Balances
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - description: Limit
+        in: query
+        maximum: 500
+        minimum: 1
+        name: limit
+        type: integer
+      - description: Offset
+        in: query
+        minimum: 0
+        name: offset
+        type: integer
+      - description: Sort Field
+        in: query
+        name: sort_field
+        type: string
+      - description: Sort Order
+        in: query
+        name: sort
+        type: string
+      - description: Contact ID
+        in: query
+        minimum: 1
+        name: contact_id
+        required: true
+        type: integer
+      - description: Balance Definition ID
+        format: uuid
+        in: query
+        name: balance_definition_id
+        required: true
+        type: string
+      - description: Include balances tied to internal definitions.
+        in: query
+        name: includeInternal
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful retrieval of active balance
+          schema:
+            $ref: '#/definitions/balanceLimit'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: subscription not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/balance/programs/{pid}/transaction-history:
+    get:
+      tags:
+        - Balance
+      consumes:
+      - application/json
+      summary: Get Transaction History API
+      description: Returns transaction history
+      parameters:
+      - description: Loyalty Program Id
+        format: uuid
+        in: path
+        name: pid
+        required: true
+        type: string
+      - default: 20
+        description: Limit the number of records returned
+        in: query
+        name: limit
+        type: integer
+      - default: 0
+        description: Page number to retrieve
+        in: query
+        name: offset
+        type: integer
+      - default: createdAt
+        description: Field to sort by
+        in: query
+        name: sortField
+        type: string
+        enum: [createdAt]
+      - default: desc
+        description: Sort order, either asc or desc
+        in: query
+        name: sort
+        type: string
+        enum: [asc, desc]
+      - default: 0
+        description: Contact ID
+        in: query
+        name: contactId
+        required: true
+        type: integer
+      - description: Balance Definition ID
+        format: uuid
+        in: query
+        name: balanceDefinitionId
+        required: true
+        type: string
+      - collectionFormat: multi
+        description: Filters to apply
+        in: query
+        items:
+          type: string
+        name: filters
+        type: array
+      - description: >-
+          Filter transactions by metadata key-value pairs using dot notation
+          (e.g., metadata.name=John).
+        in: query
+        name: metadata
+        style: deepObject
+        explode: true
+        schema:
+          type: object
+          additionalProperties:
+            type: string
+      - description: 'Transaction status filter. Allowed values: draft, completed, rejected, cancelled, expired'
+        in: query
+        name: status
+        type: string
+        enum: [draft, completed, rejected, cancelled, expired]
+      - description: 'Transaction type filter. Allowed values: credit, debit'
+        in: query
+        name: transactionType
+        type: string
+        enum: [credit, debit]
+      - description: 'Loyalty Subscription ID filter'
+        in: query
+        name: loyaltySubscriptionId
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successful retrieval of transaction history
+          schema:
+            $ref: '#/definitions/transactionHistoryResp'
+        "401":
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: subscription not found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+  /loyalty/config/programs/{pid}/contact/{cid}:
+    delete:
+      description: Delete subscription for a contact
+      tags:
+        - Program
+      parameters:
+        - description: Loyalty Program ID. A unique identifier for the loyalty program.
+          in: path
+          name: pid
+          required: true
+          schema:
+            format: uuid
+            type: string
+        - description: Contact ID.
+          in: path
+          name: cid
+          required: true
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: Successfully deleted subscription.
+          schema:
+            $ref: '#/definitions/transactionHistoryResp'
+        "401":
+          description: Request Authentication Failed.
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "403":
+          description: Cannot Authenticate Request.
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "404":
+          description: Subscription not found.
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "422":
+          description: Cannot delete subscription.
+          schema:
+            $ref: '#/definitions/errorResponse'
+        "500":
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+      summary: Delete subscription
+  # Tier
+  /loyalty/tier/programs/{pid}/tier-groups:
+    post:
+      tags:
+        - Tier
+      summary: Create a tier group
+      description: Creates a new tier group in a loyalty program. *(The changes will take effect with the next publication of the loyalty program)*
+      operationId: createTierGroup
+      parameters:
+        - name: pid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Loyalty Program ID
+        - name: payload
+          in: body
+          required: true
+          description: Tier group creation payload
+          schema:
+            $ref: "#/definitions/createTierGroupRequest"
+      responses:
+        200:
+          description: Tier group Successfully created
+          schema:
+            $ref: "#/definitions/tierGroup"
+        400:
+          description: Request is malformed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        401:
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        403:
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        409:
+          description: Conflict
+          schema:
+            $ref: "#/definitions/errorResponse"
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        422:
+          description: Validation errors
+          schema:
+            $ref: "#/definitions/errorResponse"
+        500:
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+    get:
+      tags:
+        - Tier
+      summary: List tier groups
+      description: Returns the list of tier groups defined within the loyalty program.
+      operationId: getListOfTierGroups
+      parameters:
+        - name: pid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Loyalty Program ID
+        - name: version
+          type: string
+          in: query
+          enum: [active, draft]
+          default: draft
+          description: Select 'active' to retrieve list of all tier groups which are live for clients.
+                       Select draft to retrieve list of all non deleted tier groups.
+      responses:
+        200:
+          description: Tier group list successfully retrieved
+          schema:
+            $ref: "#/definitions/tierGroupPage"
+        401:
+          description: Request Authentication Failed
+          schema:
+            $ref: "#/definitions/errorResponse"
+        403:
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        422:
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        500:
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+  /loyalty/tier/programs/{pid}/tier-groups/{gid}:
+    put:
+      tags:
+        - Tier
+      summary: Update tier group
+      description: Updates a tier group from a loyalty program. *(The changes will take effect with the next publication of the loyalty program)*
+      operationId: updateTierGroup
+      parameters:
+        - name: pid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Loyalty Program ID
+        - name: gid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Tier group ID
+        - in: body
+          name: payload
+          required: true
+          description: Tier group update payload
+          schema:
+            $ref: "#/definitions/updateTierGroupRequest"
+      responses:
+        200:
+          description: Tier group successfully updated
+          schema:
+            $ref: "#/definitions/tierGroup"
+        401:
+          description: Request Authentication Failed
+          schema:
+            $ref: "#/definitions/errorResponse"
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        403:
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        422:
+          description: Validation errors
+          schema:
+            $ref: "#/definitions/errorResponse"
+        500:
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+
+    delete:
+      tags:
+        - Tier
+      summary: Delete tier group
+      description: Deletes a tier group from a loyalty program. *(The changes will take effect with the next publication of the loyalty program)*
+      operationId: deleteTierGroup
+      parameters:
+        - name: pid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Loyalty Program ID
+        - name: gid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Tier group ID
+      responses:
+        204:
+          description: Tier group successfully deleted
+          schema:
+            type: string
+        401:
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        403:
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        409:
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errorResponse'
+        422:
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        500:
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+    get:
+      tags:
+        - Tier
+      summary: Get tier group
+      description: Returns tier group information.
+      operationId: getTierGroup
+      parameters:
+        - name: pid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Loyalty Program ID
+        - name: gid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Tier group ID
+        - name: version
+          type: string
+          in: query
+          enum: [active, draft]
+          default: draft
+          description: Select active to retrieve active version of tier group. Select draft to retrieve latest changes in tier group.
+      responses:
+        200:
+          description: Tier group information successfully retrieved
+          schema:
+            $ref: '#/definitions/tierGroup'
+        401:
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        403:
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        422:
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        500:
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+
+  /loyalty/tier/programs/{pid}/tiers:
+    get:
+      tags:
+        - Tier
+      summary: List tiers
+      description: Returns the list of tiers defined within the loyalty program.
+      operationId: getLoyaltyProgramTier
+      parameters:
+        - name: pid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Loyalty Program ID
+        - name: version
+          type: string
+          in: query
+          enum: [active, draft]
+          default: draft
+          description: Select 'active' to retrieve list of all tiers which are live for clients.
+                       Select draft to retrieve list of all non deleted tiers.
+
+      responses:
+        200:
+          description: Tier list successfully retrieved
+          schema:
+            $ref: '#/definitions/loyaltyTierPage'
+        401:
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        403:
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        422:
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        500:
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+  /loyalty/tier/programs/{pid}/tier-groups/{gid}/tiers:
+    post:
+      tags:
+        - Tier
+      summary: Create a tier
+      description: Creates a new tier in a loyalty program tier group. *(The changes will take effect with the next publication of the loyalty program)*
+      operationId: createTierForTierGroup
+      parameters:
+        - name: pid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Loyalty Program ID
+        - name: gid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Tier group ID
+        - name: payload
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/tierRequest'
+      responses:
+        200:
+          description: Tier successfully created
+          schema:
+            $ref: '#/definitions/tier'
+        401:
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        403:
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        422:
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        500:
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+  /loyalty/tier/programs/{pid}/tiers/{tid}:
+    delete:
+      tags:
+        - Tier
+      summary: Delete tier
+      description: Deletes a tier from a loyalty program tier group. *(The changes will take effect with the next publication of the loyalty program)*
+      operationId: deleteTier
+      parameters:
+        - name: pid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Loyalty Program ID
+        - name: tid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Tier ID
+      responses:
+        204:
+          description: Tier successfully deleted
+          schema:
+            type: string
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        401:
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        403:
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        422:
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        500:
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+    put:
+      tags:
+        - Tier
+      summary: Update tier
+      description: Modifies an existing tier for the specified tier group *(The changes will take effect with the next publication of the loyalty program)*
+      operationId: updateTier
+      parameters:
+        - name: pid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Loyalty Program ID
+        - name: tid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Tier ID
+        - name: payload
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/tierRequestPutPayload'
+      responses:
+        200:
+          description: Tier successfully updated
+          schema:
+            $ref: '#/definitions/tier'
+        401:
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        403:
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        422:
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        500:
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+  /loyalty/tier/programs/{pid}/contacts/{cid}/tiers/{tid}:
+    post:
+      tags:
+        - Tier
+      summary: Assign a tier
+      description: Manually assigns a tier to a specific membership.
+      operationId: addSubscriptionToTier
+      parameters:
+        - name: pid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Loyalty Program ID
+        - name: cid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Contact ID
+        - name: tid
+          in: path
+          required: true
+          type: string
+          format: uuid
+          description: Tier ID
+      responses:
+        200:
+          description: Tier successfully assigned to membership
+          schema:
+            $ref: '#/definitions/tierForContact'
+        401:
+          description: Request Authentication Failed
+          schema:
+            $ref: '#/definitions/errorResponse'
+        403:
+          description: Cannot Authenticate Request
+          schema:
+            $ref: '#/definitions/errorResponse'
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorResponse'
+        409:
+          description: Conflict
+          schema:
+            $ref: '#/definitions/errorResponse'
+        424:
+          description: Failed Dependency
+          schema:
+            $ref: '#/definitions/errorResponse'
+        422:
+          description: Validation errors
+          schema:
+            $ref: '#/definitions/errorResponse'
+        500:
+          description: Internal error occurred
+          schema:
+            $ref: '#/definitions/errorResponse'
+
+  /senders:
+    get:
+      tags:
+        - Senders
+      summary: Get the list of all your senders
+      operationId: getSenders
+      parameters:
+        - name: ip
+          description: Filter your senders for a specific ip (available for dedicated IP usage only)
+          in: query
+          type: string
+        - name: domain
+          description: Filter your senders for a specific domain
+          in: query
+          type: string
+      responses:
+        '200':
+          description: list of senders
+          schema:
+            $ref: '#/definitions/getSendersList'
+          examples:
+            application/json:
+                {
+                  "senders": [
+                    {
+                      "id": 1,
+                      "name": "Marketing",
+                      "email": "marketing@mycompany.com",
+                      "active": true,
+                      "ips": [
+                        {
+                          "ip": "123.98.689.7",
+                          "domain": "mycompany.com",
+                          "weight": 100
+                        }
+                      ]
+                    },
+                    {
+                      "id": 2,
+                      "name": "Newsletter",
+                      "email": "newsletter@mycompany.com",
+                      "active": false,
+                      "ips": [
+                        {
+                          "ip": "123.98.689.7",
+                          "domain": "mycompany.com",
+                          "weight" : 50
+                        },
+                        {
+                          "ip": "123.98.643.2",
+                          "domain": "news.mycompany.com",
+                          "weight": 50
+                        }
+                      ]
+                    }
+                  ]
+                }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+        - Senders
+      summary: Create a new sender
+      operationId: createSender
+      parameters:
+        - name: sender
+          description: sender's name
+          in: body
+          schema:
+            $ref: '#/definitions/createSender'
+      responses:
+        '201':
+          description: sender created
+          schema:
+            $ref: '#/definitions/createSenderModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /senders/{senderId}:
+    put:
+      tags:
+        - Senders
+      summary: Update a sender
+      operationId: updateSender
+      parameters:
+        - name: senderId
+          description: Id of the sender
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: sender
+          description: sender's name
+          in: body
+          schema:
+            $ref: '#/definitions/updateSender'
+      responses:
+        '204':
+          description: sender updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Sender ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+        - Senders
+      summary: Delete a sender
+      operationId: deleteSender
+      parameters:
+        - name: senderId
+          description: Id of the sender
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '204':
+          description: sender deleted
+        '404':
+          description: Sender ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /senders/{senderId}/validate:
+    put:
+      tags:
+        - Senders
+      summary: Update a sender
+      operationId: validateSenderByOTP
+      parameters:
+        - name: senderId
+          description: Id of the sender
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: otp
+          description: otp
+          in: body
+          schema:
+            $ref: '#/definitions/otp'
+      responses:
+        '204':
+          description: sender updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Sender ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /senders/{senderId}/ips:
+    get:
+      tags:
+        - Senders
+      summary: Get all the dedicated IPs for a sender
+      operationId: getIpsFromSender
+      parameters:
+        - name: senderId
+          description: Id of the sender
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '200':
+          description: list of dedicated IPs
+          schema:
+            $ref: '#/definitions/getIpsFromSender'
+          examples:
+            application/json:
+             {
+              "ips": [
+                {
+                  "id": 3,
+                  "ip": "123.65.8.22",
+                  "domain": "mailing.myshop.dom",
+                  "weight": 40
+                },
+                {
+                  "id": 5,
+                  "ip": "123.43.21.3",
+                  "domain": "newsletter.myshop.dom",
+                  "weight": 60
+                }
+              ]
+            }
+        '404':
+          description: Sender ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /senders/ips:
+    get:
+      tags:
+        - Senders
+      summary: Get all the dedicated IPs for your account
+      operationId: getIps
+      responses:
+        '200':
+          description: list of dedicated IPs
+          schema:
+            $ref: '#/definitions/getIps'
+          examples:
+            application/json:
+                {
+                  "ips": [
+                    {
+                      "id": 3,
+                      "ip": "67.145.89.3",
+                      "active": true,
+                      "domain": "mailing.myshop.com",
+                    },
+                    {
+                      "id": 5,
+                      "ip": "76.76.125.9",
+                      "active": true,
+                      "domain": "newsletter.myshop.com",
+                    },
+                    {
+                      "id": 6,
+                      "ip": "123.65.8.22",
+                      "active": false,
+                      "domain": "notifications.myshop.com",
+                    }
+                  ]
+                }
+  /senders/domains:
+    get:
+      tags:
+      - Domains
+      summary: Get the list of all your domains
+      operationId: getDomains
+      responses:
+        '200':
+          description: list of domains
+          schema:
+            $ref: '#/definitions/getDomainsList'
+          examples:
+            application/json:
+                {
+                  "domains": [
+                    {
+                      "id": 1,
+                      "domain_name": "mycompany.com",
+                      "authenticated": true,
+                      "verified": true,
+                      "ip": "123.98.689.7"
+                    },
+                    {
+                      "id": 2,
+                      "domain_name": "myexample.com",
+                      "authenticated": false,
+                      "verified": true,
+                      "ip": null
+                    }
+                  ]
+                }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+        tags:
+        - Domains
+        summary: Create a new domain
+        operationId: createDomain
+        parameters:
+          - name: domainName
+            description: domain's name
+            in: body
+            schema:
+              $ref: '#/definitions/createDomain'
+            required: false
+        responses:
+          '200':
+            description: domain created
+            schema:
+              $ref: '#/definitions/createDomainModel'
+          '400':
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+  /senders/domains/{domainName}:
+    delete:
+      tags:
+      - Domains
+      summary: Delete a domain
+      operationId: deleteDomain
+      parameters:
+        - name: domainName
+          in: path
+          description: Domain name
+          required: true
+          type: string
+      responses:
+        '200':
+          description: domain deleted
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Domain does not exist
+          schema:
+            $ref: '#/definitions/errorModel'
+    get:
+      tags:
+      - Domains
+      summary: Validate domain configuration
+      operationId: getDomainConfiguration
+      parameters:
+        - name: domainName
+          in: path
+          description: Domain name
+          required: true
+          type: string
+      responses:
+        '200':
+          description: domain configuration
+          schema:
+            $ref: '#/definitions/getDomainConfigurationModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Domain does not exist
+          schema:
+            $ref: '#/definitions/errorModel'
+  /senders/domains/{domainName}/authenticate:
+    put:
+      tags:
+      - Domains
+      summary: Authenticate a domain
+      operationId: authenticateDomain
+      parameters:
+        - name: domainName
+          in: path
+          description: Domain name
+          required: true
+          type: string
+      responses:
+        '200':
+          description: domain authenticated
+          schema:
+            $ref: '#/definitions/authenticateDomainModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Domain does not exist
+          schema:
+            $ref: '#/definitions/errorModel'
+
+  /webhooks:
+    get:
+      tags:
+          - Webhooks
+      summary: Get all webhooks
+      operationId: getWebhooks
+      parameters:
+        - name: type
+          description: Filter on webhook type
+          in: query
+          required: false
+          type: string
+          enum:
+            - marketing
+            - transactional
+            - inbound
+          default: transactional
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of webhook creation
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: Webhooks informations
+          schema:
+            $ref: '#/definitions/getWebhooks'
+          examples:
+            application/json:
+              {
+                "webhooks":[
+                  {
+                    "url": "https://example.domain.com/webhook/events/kzfxxxxxxxx0uyo1",
+                    "id": 9864,
+                    "description": "Webhook triggered on campaign openings",
+                    "events": [
+                      "opened"
+                            ],
+                    "type": "transac",
+                    "channel":"email",
+                    "createdAt": "2016-07-18T12:30:09Z",
+                    "modifiedAt": "2016-07-18T16:00:50Z"
+                  },
+                  {
+                    "url": "http://exmaple.domain.com/15kxxxxxn1",
+                    "id": 22770,
+                    "description": "Webhook triggered on campaign hard bounces",
+                    "events": [
+                      "hardBounces"
+                              ],
+                    "type": "marketing",
+                    "channel":"sms",
+                    "createdAt": "2017-02-20T14:30:00Z",
+                    "modifiedAt": "2017-02-20T19:00:00Z"
+                  }
+                ]
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+          - Webhooks
+      summary: Create a webhook
+      operationId: createWebhook
+      parameters:
+        - name: createWebhook
+          description: Values to create a webhook
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/createWebhook'
+      responses:
+        '201':
+          description: Webhook created
+          schema:
+            $ref: '#/definitions/createModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /webhooks/{webhookId}:
+    get:
+      tags:
+          - Webhooks
+      summary: Get a webhook details
+      operationId: getWebhook
+      parameters:
+        - name: webhookId
+          description: Id of the webhook
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '200':
+          description: Webhook informations
+          schema:
+            $ref: '#/definitions/getWebhook'
+          examples:
+            application/json:
+              {
+                "url": "http://example.domain.com/1brxxxxxx5p1",
+                "id": 7287,
+                "description": "Webhook triggered on campaign openings and addition of lists",
+                "events": [
+                  "listAdditions",
+                  "opened"
+                         ],
+                "type": "marketing",
+                "channel":"sms",
+                "createdAt": "2016-06-07T09:10:10Z",
+                "modifiedAt": "2016-06-08T11:30:00Z"
+              }
+        '404':
+          description: Webhook ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+          - Webhooks
+      summary: Update a webhook
+      operationId: updateWebhook
+      parameters:
+        - name: webhookId
+          description: Id of the webhook
+          in: path
+          type: integer
+          format: int64
+          required: true
+        - name: updateWebhook
+          description: Values to update a webhook
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/updateWebhook'
+      responses:
+        '204':
+          description: Webhook updated
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Webhook ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+          - Webhooks
+      summary: Delete a webhook
+      operationId: deleteWebhook
+      parameters:
+        - name: webhookId
+          description: Id of the webhook
+          in: path
+          type: integer
+          format: int64
+          required: true
+      responses:
+        '204':
+          description: Webhook deleted
+        '404':
+          description: Webhook ID not found
+          schema:
+            $ref: '#/definitions/errorModel'
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /webhooks/export:
+    post:
+      tags:
+        - Webhooks
+      summary: Export all webhook events
+      description: This endpoint will submit a request to get the history of webhooks in the CSV file. The link to download the CSV file will be sent to the webhook that was provided in the notifyURL.
+      operationId: exportWebhooksHistory
+      parameters:
+        - name: Export webhook history
+          description: Values to submit for webhooks history
+          in: body
+          schema:
+            $ref: '#/definitions/exportWebhooksHistory'
+          required: true
+      responses:
+        202:
+          description: Request accepted
+          schema:
+            $ref: '#/definitions/createdProcessId'
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+
+  /account:
+    get:
+      tags:
+        - Account
+      summary: Get your account information, plan and credits details
+      operationId: getAccount
+      responses:
+        '200':
+          description: account informations
+          schema:
+            $ref: '#/definitions/getAccount'
+          examples:
+            application/json :
+              {
+                "plan": [
+                  {
+                    "type": "payAsYouGo",
+                    "credits": 5000,
+                    "creditsType": "sendLimit"
+                  },
+                  {
+                    "type": "subscription",
+                    "credits": 39983,
+                    "creditsType": "sendLimit",
+                    "startDate": "2017-03-11",
+                    "endDate": "2017-04-11"
+                  },
+                  {
+                    "type": "sms",
+                    "credits": 999.5360000000001,
+                    "creditsType": "sendLimit"
+                  }
+                ],
+                "relay": {
+                  "enabled": true,
+                  "data": {
+                    "userName": "john.smith@example.com",
+                    "relay": "smtp-relay.domain.com",
+                    "port": 587
+                  }
+                },
+                "marketingAutomation": {
+                  "key": "kzfr5xxxxxxttuyo1",
+                  "enabled": true
+                },
+                "email": "john.smith@example.com",
+                "firstName": "John",
+                "lastName": "Smith",
+                "companyName": "MyShop",
+                "address": {
+                  "city": "New-York",
+                  "street": "1677B 8th Avenue",
+                  "zipCode": "7665",
+                  "country": "USA"
+                }
+              }
+  /organization/activities:
+    get:
+      tags:
+      - Account
+      - Master account
+      summary: Get user activity logs
+      operationId: getAccountActivity
+      parameters:
+        - name: startDate
+          description: Mandatory if endDate is used. Enter start date in UTC date (YYYY-MM-DD) format to filter the activity in your account. Maximum time period that can be selected is one month. Additionally, you can retrieve activity logs from the past 12 months from the date of your search.
+          in: query
+          required: false
+          type: string
+        - name: endDate
+          description: Mandatory if startDate is used. Enter end date in UTC date (YYYY-MM-DD) format to filter the activity in your account. Maximum time period that can be selected is one month.
+          in: query
+          required: false
+          type: string
+        - name: email
+          description: Enter the user's email address to filter their activity in the account.
+          in: query
+          required: false
+          type: string
+        - name: limit
+          description: Number of documents per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 10
+          maximum: 100
+          minimum: 1
+        - name: offset
+          description: Index of the first document in the page.
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default : 0
+      responses:
+        '200':
+          description: list of user activity logs
+          schema:
+            $ref: '#/definitions/getAccountActivity'
+          examples:
+            application/json:
+                {
+                  "logs": [
+                    {
+                      "action": "login-success",
+                      "date": "2023-03-16T16:49:23+05:30",
+                      "user_email": "test@mycompany.com",
+                      "user_ip": "192.158.1.34",
+                      "user_agent": "Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us)"
+                    },
+                    {
+                      "action": "update-profile",
+                      "date": "2023-03-17T16:49:23+05:30",
+                      "user_email": "test@myexample.com",
+                      "user_ip": "192.158.1.38",
+                      "user_agent": "Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us)"
+                    }
+                  ],
+                  "count": 2
+                }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /organization/invited/users:
+    get:
+      tags:
+      - User
+      summary: Get the list of all your users
+      operationId: getInvitedUsersList
+      responses:
+        '200':
+          description: list of all your users
+          schema:
+            $ref: '#/definitions/getInvitedUsersList'
+          examples:
+            application/json:
+                {
+                  "users": [
+                    {
+                      "email": "owner@company.com",
+                      "is_owner": true,
+                      "status": "active",
+                      "feature_access": {
+                        "marketing": "owner",
+                        "conversations": "owner",
+                        "crm": "owner"
+                      }
+                    },
+                    {
+                      "email": "pendingInvitedUser@company.com",
+                      "is_owner": false,
+                      "status": "pending",
+                      "feature_access": {
+                        "marketing": "custom",
+                        "conversations": "none",
+                        "crm": "full"
+                      }
+                    },
+                    {
+                      "email": "connectedInvitedUser@company.com",
+                      "is_owner": false,
+                      "status": "active",
+                      "feature_access": {
+                        "marketing": "none",
+                        "conversations": "full",
+                        "crm": "none"
+                      }
+                    }
+                  ]
+                }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /organization/user/{email}/permissions:
+    get:
+      tags:
+      - User
+      summary: Check user permission
+      operationId: getUserPermission
+      parameters:
+        - name: email
+          description: Email of the invited user.
+          in: path
+          required: true
+          type: string
+      responses:
+        '200':
+          description: list of all the user's permissions
+          schema:
+            $ref: '#/definitions/getUserPermission'
+          examples:
+            application/json:
+                {
+                  "email": "invitedUser@company.com",
+                  "status": "active",
+                  "privileges": [
+                    {
+                      "feature": "Email campaign",
+                      "permissions": [
+                        "Create / edit / delete",
+                        "Send / schedule / suspend"
+                      ]
+                    },
+                    {
+                      "feature": "Templates",
+                      "permissions": [
+                        "Create / edit / delete",
+                        "Activate / deactivate"
+                      ]
+                    },
+                    {
+                      "feature": "SMS campaign",
+                      "permissions": [
+                        "Create / edit / delete",
+                        "Send / schedule / suspend"
+                      ]
+                    },
+                    {
+                      "feature": "Facebook Ads",
+                      "permissions": [
+                        "Schedule / pause"
+                      ]
+                    },
+                    {
+                      "feature": "Landing pages",
+                      "permissions": [
+                        "All"
+                      ]
+                    },
+                    {
+                      "feature": "Workflows",
+                      "permissions": [
+                        "Create / edit / delete",
+                        "Activate / deactivate / Pause"
+                      ]
+                    },
+                    {
+                      "feature": "Contacts",
+                      "permissions": [
+                        "View",
+                        "Contact forms"
+                      ]
+                    },
+                    {
+                      "feature": "SMTP & API",
+                      "permissions": [
+                        "SMTP",
+                        "API Keys",
+                        "Authorized IPs"
+                      ]
+                    },
+                    {
+                      "feature": "User management",
+                      "permissions": [
+                        "None"
+                      ]
+                    },
+                    {
+                      "feature": "Sales Platform",
+                      "permissions": [
+                        "Create / edit / delete owned deals and tasks",
+                        "Manage deals and tasks from other users",
+                        "Reports",
+                        "Settings"
+                      ]
+                    },
+                    {
+                      "feature": "Conversations",
+                      "permissions": [
+                        "None"
+                      ]
+                    },
+                    {
+                      "feature": "Senders, Domains & Dedicated IPs",
+                      "permissions": [
+                        "Senders management",
+                        "Domains management",
+                        "Dedicated IPs management"
+                      ]
+                    },
+                    {
+                      "feature": "Push",
+                      "permissions": [
+                        "View",
+                        "Create / edit / delete",
+                        "Send",
+                        "Settings"
+                      ]
+                    },
+                    {
+                      "feature": "Companies",
+                      "permissions": [
+                        "Create / edit / delete owned companies",
+                        "Manage companies from other users",
+                        "Settings"
+                      ]
+                    }
+                  ]
+                }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /organization/user/invitation/revoke/{email}:
+    put:
+      tags:
+      - User
+      summary: Revoke user permission
+      operationId: putRevokeUserPermission
+      parameters:
+        - name: email
+          description: Email of the invited user.
+          in: path
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/putRevokeUserPermission'
+          examples:
+            application/json:
+              {
+                "status": "OK",
+                "credit_notes": [
+                  "TEST-123"
+                ]
+              }
+        '403':
+          description: Unauthorized access
+          schema:
+            $ref: '#/definitions/errorModel'
+  /organization/user/invitation/{action}/{email}:
+    put:
+      tags:
+      - User
+      summary: Resend / Cancel invitation
+      operationId: putresendcancelinvitation
+      parameters:
+        - name: action
+          description: action
+          in: path
+          required: true
+          type: string
+          enum:
+            - resend
+            - cancel
+        - name: email
+          description: Email of the invited user.
+          in: path
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/putresendcancelinvitation'
+          examples:
+            application/json:
+              {
+                "status": "OK",
+                "credit_notes": [
+                  "TEST-123"
+                ]
+              }
+        '403':
+          description: Unauthorized access
+          schema:
+            $ref: '#/definitions/errorModel'
+  /organization/user/invitation/send:
+    post:
+      tags:
+      - User
+      summary: Send invitation to user
+      description: |
+        `Feature` - A Feature represents a specific functionality like Email campaign, Deals, Calls, Automations, etc. on Brevo. While inviting a user, determine which feature you want to manage access to. You must specify the feature accurately to avoid errors.
+
+        `Permission` - A Permission defines the level of access or control a user has over a specific feature. While inviting user, decide on the permission level required for the selected feature. Make sure the chosen permission is related to the selected feature.
+
+        Features and their respective permissions are as below:
+
+        - `email_campaigns`:
+          - "create_edit_delete"
+          - "send_schedule_suspend"
+        - `sms_campaigns`:
+          - "create_edit_delete"
+          - "send_schedule_suspend"
+        - `contacts`:
+          - "view"
+          - "create_edit_delete"
+          - "import"
+          - "export"
+          - "list_and_attributes"
+          - "forms"
+        - `templates`:
+          - "create_edit_delete"
+          - "activate_deactivate"
+        - `workflows`:
+          - "create_edit_delete"
+          - "activate_deactivate_pause"
+          - "settings"
+        - `landing_pages`:
+          - "all"
+        - `transactional_emails`:
+          - "settings"
+          - "logs"
+        - `smtp_api`:
+          - "smtp"
+          - "api_keys"
+          - "authorized_ips"
+        - `user_management`:
+          - "all"
+        - `sales_platform`:
+          - "create_edit_deals"
+          - "delete_deals"
+          - "manage_others_deals_tasks"
+          - "reports"
+          - "settings"
+        - `phone`:
+          - "all"
+        - `conversations`:
+          - "access"
+          - "assign"
+          - "configure"
+        - `senders_domains_dedicated_ips`:
+          - "senders_management"
+          - "domains_management"
+          - "dedicated_ips_management"
+        - `push_notifications`:
+          - "view"
+          - "create_edit_delete"
+          - "send"
+          - "settings"
+        - `companies`:
+          - "manage_owned_companies"
+          - "manage_other_companies"
+          - "settings"
+
+        **Note**:
+        - If `all_features_access: false` then only privileges are required otherwise if `true` then it's assumed that all permissions will be there for the invited user.
+        - The availability of feature and its permission depends on your current plan. Please select the features and permissions accordingly.
+
+      operationId: inviteuser
+      parameters:
+        - name: sendInvitation
+          description: Values to create an invitation
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/inviteuser'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/inviteuser'
+          examples:
+            application/json:
+              {
+                "status": "OK",
+                "invoice_id": "TEST-123"
+              }
+        '400':
+          description: Bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /organization/user/update/permissions:
+    post:
+      tags:
+      - User
+      summary: Update permission for a user
+      description: |
+        `Feature` - A Feature represents a specific functionality like Email campaign, Deals, Calls, Automations, etc. on Brevo. While inviting a user, determine which feature you want to manage access to. You must specify the feature accurately to avoid errors.
+
+        `Permission` - A Permission defines the level of access or control a user has over a specific feature. While inviting user, decide on the permission level required for the selected feature. Make sure the chosen permission is related to the selected feature.
+
+        Features and their respective permissions are as below:
+
+        - `email_campaigns`:
+          - "create_edit_delete"
+          - "send_schedule_suspend"
+        - `sms_campaigns`:
+          - "create_edit_delete"
+          - "send_schedule_suspend"
+        - `contacts`:
+          - "view"
+          - "create_edit_delete"
+          - "import"
+          - "export"
+          - "list_and_attributes"
+          - "forms"
+        - `templates`:
+          - "create_edit_delete"
+          - "activate_deactivate"
+        - `workflows`:
+          - "create_edit_delete"
+          - "activate_deactivate_pause"
+          - "settings"
+        - `landing_pages`:
+          - "all"
+        - `transactional_emails`:
+          - "settings"
+          - "logs"
+        - `smtp_api`:
+          - "smtp"
+          - "api_keys"
+          - "authorized_ips"
+        - `user_management`:
+          - "all"
+        - `sales_platform`:
+          - "create_edit_deals"
+          - "delete_deals"
+          - "manage_others_deals_tasks"
+          - "reports"
+          - "settings"
+        - `phone`:
+          - "all"
+        - `conversations`:
+          - "access"
+          - "assign"
+          - "configure"
+        - `senders_domains_dedicated_ips`:
+          - "senders_management"
+          - "domains_management"
+          - "dedicated_ips_management"
+        - `push_notifications`:
+          - "view"
+          - "create_edit_delete"
+          - "send"
+          - "settings"
+        - `companies`:
+          - "manage_owned_companies"
+          - "manage_other_companies"
+          - "settings"
+
+        **Note**:
+        - The privileges array remains the same as in the send invitation; the user simply needs to provide the permissions that need to be updated.
+        - The availability of feature and its permission depends on your current plan. Please select the features and permissions accordingly.
+
+      operationId: EditUserPermission
+      parameters:
+        - name: updatePermissions
+          description: Values to update permissions for an invited user
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/inviteuser'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/inviteuser'
+          examples:
+            application/json:
+              {
+                "status": "OK",
+                "invoice_id": "TEST-123",
+                "credit_notes": [
+                  "TEST-123"
+                ]
+              }
+        '403':
+          description: Access Denied
+          schema:
+            $ref: '#/definitions/errorModel'
+
+  /processes:
+    get:
+        tags:
+          - Process
+        summary: Return all the processes for your account
+        operationId: getProcesses
+        parameters:
+        - name: limit
+          description: Number limitation for the result returned
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 10
+          maximum: 50
+          minimum: 0
+        - name: offset
+          description: Beginning point in the list to retrieve from.
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 0
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+        responses:
+            '200':
+              description: processes informations
+              schema:
+                $ref: '#/definitions/getProcesses'
+              examples:
+                application/json:
+                  {
+                    "processes": [
+                      {
+                      "id": 40,
+                      "status": "completed",
+                      "name": "TRANS-CALC"
+                      },
+                      {
+                      "id": 43,
+                      "status": "queued",
+                      "name": "TRANS-GLOBAL-CALC"
+                      },
+                      {
+                      "id": 194,
+                      "status": "completed",
+                      "name": "SEARCH_EXPORT_USERS",
+                      "export_url": "<a href=\"https://export-url.com/upload/file-name.csv\" target=\"_blank\">filename.csv</a>"
+                      }
+                      ],
+                  "count": 3
+                  }
+            '400':
+              description: bad request
+              schema:
+                $ref: '#/definitions/errorModel'
+  /processes/{processId}:
+    get:
+        tags:
+          - Process
+        summary: Return the informations for a process
+        operationId: getProcess
+        parameters:
+          - name: processId
+            description: Id of the process
+            in: path
+            type: integer
+            format: int64
+            required: true
+        responses:
+            '200':
+              description: process informations
+              schema:
+                $ref: '#/definitions/getProcess'
+              examples:
+                application/json:
+                  {
+                      "id": 194,
+                      "status": "completed",
+                      "name": "SEARCH_EXPORT_USERS",
+                      "export_url": "<a href=\"https://export-url.com/upload/file-name.csv\" target=\"_blank\">filename.csv</a>"
+                  }
+            '404':
+              description: Process ID not found
+              schema:
+                $ref: '#/definitions/errorModel'
+              examples:
+                application/json:
+                  {
+                    "code": "invalid_parameter",
+                    "message": "processId is invalid"
+                  }
+            '400':
+              description: bad request
+              schema:
+                $ref: '#/definitions/errorModel'
+  /inbound/events:
+    get:
+      tags:
+        - Inbound Parsing
+      summary: Get the list of all the events for the received emails.
+      description: This endpoint will show the list of all the events for the received emails.
+      operationId: getInboundEmailEvents
+      parameters:
+        - name: sender
+          description: Email address of the sender.
+          in: query
+          required: false
+          type: string
+        - name: startDate
+          description: Mandatory if endDate is used. Starting date (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss.SSSZ) from which you want to fetch the list. Maximum time period that can be selected is one month.
+          in: query
+          required: false
+          type: string
+          format: datetime
+        - name: endDate
+          description: Mandatory if startDate is used. Ending date (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss.SSSZ) till which you want to fetch the list. Maximum time period that can be selected is one month.
+          in: query
+          required: false
+          type: string
+          format: datetime
+        - name: limit
+          description: Number of documents returned per page
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 100
+          maximum: 500
+          minimum: 0
+        - name: offset
+          description: Index of the first document on the page
+          in: query
+          required: false
+          type: integer
+          format : int64
+          default: 0
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation
+          required: false
+          type: string
+          enum:
+            - asc
+            - desc
+          default: desc
+      responses:
+        '200':
+          description: List of events for received emails.
+          schema:
+            $ref: '#/definitions/getInboundEmailEvents'
+          examples:
+            application/json:
+              {
+                "events": [
+                  {
+                    "uuid": "1a825d56-029b-4a41-b8e4-1a825d56",
+                    "date": "2017-03-11T12:30:00.000Z",
+                    "sender": "john@example.com",
+                    "recipient": "alexa@example.com"
+                  },
+                  {
+                    "uuid": "1a825d56-029b-4a41-b8e4-61670463431b",
+                    "date": "2017-03-12T12:30:00.000Z",
+                    "sender": "alice@example.com",
+                    "recipient": "bob@example.com"
+                  }
+                ]
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /inbound/events/{uuid}:
+    get:
+      tags:
+        - Inbound Parsing
+      summary: Fetch all events history for one particular received email.
+      description: This endpoint will show the list of all events history for one particular received email.
+      operationId: getInboundEmailEventsByUuid
+      parameters:
+        - name: uuid
+          description: 'UUID to fetch events specific to recieved email'
+          type: string
+          in: path
+          required: true
+      responses:
+        '200':
+          description: List of events for a particular received email on the basis of uuid.
+          schema:
+            $ref: '#/definitions/getInboundEmailEventsByUuid'
+          examples:
+            application/json:
+              {
+                "receivedAt": "2017-03-12T12:30:00.000Z",
+                "deliveredAt": "2017-03-12T12:31:00.000Z",
+                "sender": "alice@example.com",
+                "recipient": "bob@example.com",
+                "messageId": "<a_nice@message.id>",
+                "subject": "Re: Question about your API",
+                "attachments": [
+                  {
+                    "name": "invoice.pdf",
+                    "contentType": "application/pdf",
+                    "contentId": null,
+                    "contentLength": 12345,
+                  }
+                ],
+                "logs": [
+                          {
+                            "date": "2017-03-12T12:30:00.000Z",
+                            "type": "received"
+                          },
+                          {
+                            "date": "2017-03-12T12:30:04.000Z",
+                            "type": "webhookFailed"
+                          },
+                          {
+                            "date": "2017-03-12T12:31:04.000Z",
+                            "type": "webhookDelivered"
+                          }
+                        ]
+              }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /inbound/attachments/{downloadToken}:
+    get:
+      tags:
+        - Inbound Parsing
+      summary: Retrieve inbound attachment with download token.
+      description: This endpoint will retrieve inbound attachment with download token.
+      operationId: getInboundEmailAttachment
+      parameters:
+      - name: downloadToken
+        description: 'Token to fetch a particular attachment'
+        type: string
+        in: path
+        required: true
+      responses:
+        200:
+          description: Attachment information
+          schema:
+            type: file
+            format: binary
+          headers:
+            Content-Type:
+              type: string
+              description: "example: image/png"
+            Content-Disposition:
+              type: string
+              description: "example: attachment; filename=\"download.png\""
+            Content-Length:
+              type: integer
+              description: "example: 4032"
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: attachment not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /corporate/subAccount:
+    get:
+      tags:
+        - Master account
+      summary: Get the list of all the sub-accounts of the master account.
+      description: This endpoint will provide the list all the sub-accounts of the master account.
+      parameters:
+      - name: offset
+        description: 'Index of the first sub-account in the page'
+        in: query
+        required: true
+        type: integer
+      - name: limit
+        description: 'Number of sub-accounts to be displayed on each page'
+        in: query
+        required: true
+        type: integer
+      responses:
+        200:
+          description: Sub-accounts list
+          schema:
+            $ref: '#/definitions/subAccountsResponse'
+          examples:
+            application/json:
+              {
+                "count": 3,
+                "subAccounts": [
+                  {
+                    "id": 4043629,
+                    "companyName": "Company1",
+                    "active": true,
+                    "createdAt": 1629439311,
+                    "groups": [
+                      {"id": "5f8f8c3b5f56a02d4433b3a8", "name": "Group 1"},
+                      {"id": "4fbf3c3b1f56a02ac465b1a0", "name": "Group 2"},
+                    ]
+                  },
+                  {
+                    "id": 3984002,
+                    "companyName": "Company2",
+                    "active": true,
+                    "createdAt": 1629439311,
+                    "groups": []
+                  },
+                  {
+                    "id": 3524191,
+                    "companyName": "Company3",
+                    "active": true,
+                    "createdAt": 1614713641,
+                    "groups": []
+                  }
+                ]
+              }
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+        - Master account
+      summary: Create a new sub-account under a master account.
+      description: This endpoint will create a new sub-account under a master account
+      parameters:
+        - name: subAccountCreate
+          description: values to create new sub-account
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/createSubAccount'
+
+      responses:
+        201:
+          description: Created sub-account ID
+          schema:
+            $ref: '#/definitions/createSubAccountResponse'
+          examples:
+            application/json:
+              {
+                id: 8767868
+              }
+
+        400:
+          description: Bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                code: missing_parameter,
+                message: 'Missing companyName attribute in the request'
+              }
+  /corporate/subAccount/{id}:
+    get:
+      tags:
+        - Master account
+      summary: Get sub-account details
+      description: This endpoint will provide the details for the specified sub-account company
+      parameters:
+        - name: id
+          description: 'Id of the sub-account organization'
+          type: integer
+          format: int64
+          in: path
+          required: true
+      responses:
+        200:
+          description: Sub-account organization details
+          schema:
+            $ref: '#/definitions/subAccountDetailsResponse'
+          examples:
+            application/json:
+              {
+                "name": "Uday Pandit",
+                "email": "uday+1@brevo.com",
+                "companyName": "API-Sub-26thOct21-4",
+                "groups":[
+                  {
+                    "id": "5f8f8c3b5f56a02d4433b3a7",
+                    "name": "Group 1"
+                  },
+                  {
+                    "id": "5f8f8c3b5f56a02d4433b3a8",
+                    "name": "Group 2"
+                  }
+                ],
+                "planInfo":
+                {
+                    "credits":
+                    {
+                      "emails":
+                      {
+                        "quantity": 2000,
+                        "remaining": 1955
+                      },
+                      "sms":
+                      {
+                        "quantity": 2000,
+                        "remaining": 1955
+                      },
+                      "wpSubscribers":
+                      {
+                        "quantity": 2000,
+                        "remaining": 1955
+                      },
+                      "whatsapp":
+                      {
+                        "quantity": 100,
+                        "remaining": 50
+                      },
+                      "externalFeeds":
+                      {
+                        "quantity": 1,
+                        "remaining": 1
+                      }
+                    },
+                    "features":
+                    {
+                      "inbox":
+                      {
+                        "quantity": 20,
+                        "remaining": 12
+                      },
+                      "landingPage":
+                      {
+                        "quantity": 25,
+                        "remaining": 14
+                      },
+                      "users":
+                      {
+                        "quantity": 30,
+                        "remaining": 14
+                      },
+                      "salesUsers":
+                      {
+                        "quantity": 30,
+                        "remaining": 14
+                      }
+                    },
+                    "planType": "paid"
+                 }
+              }
+    delete:
+      tags:
+        - Master account
+      summary: Delete a sub-account
+      parameters:
+      - name: id
+        description: 'Id of the sub-account organization to be deleted'
+        type: integer
+        format: int64
+        in: path
+        required: true
+      responses:
+        204:
+          description: Returned when sub-account is deleted succesfully
+        400:
+          description: bad request
+          examples:
+            application/json:
+              {
+                "message": "Sub-account 2039dfsddf885 is not valid",
+                "code": "missing_parameter"
+              }
+        404:
+          description: Organization not found
+          examples:
+            application/json:
+              {
+                "message": "Sub-account 2039885 was not found",
+                "code": "document_not_found"
+              }
+
+  /corporate/subAccount/{id}/plan:
+    put:
+      tags:
+        - Master account
+      summary: Update sub-account plan
+      description: This endpoint will update the sub-account plan. On the Corporate solution new version v2, you can set an unlimited number of credits in your sub-organization. Please pass the value “-1" to set the consumable in unlimited mode.
+      parameters:
+        - name: id
+          description: 'Id of the sub-account organization'
+          type: integer
+          format: int64
+          in: path
+          required: true
+        - name: updatePlanDetails
+          description: Values to update a sub-account plan
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/subAccountUpdatePlanRequest'
+      responses:
+        204:
+          description: Sub account plan updated
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        403:
+          description: Current account is not a master account
+          schema:
+              $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+                {
+                  code: "permission_denied",
+                  message: "Access forbidden."
+                }
+  /corporate/subAccounts/plan:
+    put:
+      tags:
+        - Master account
+      summary: Update sub-accounts plan
+      description: This endpoint will update multiple sub-accounts plan. On the Corporate solution new version v2, you can set an unlimited number of credits in your sub-organization. Please pass the value “-1" to set the consumable in unlimited mode.
+      parameters:
+        - name: updatePlanDetails
+          description: Values to update sub-accounts plan
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/subAccountsUpdatePlanRequest'
+      responses:
+        202:
+          description: Request accepted
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        403:
+          description: Current account is not a master account
+          schema:
+              $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+                {
+                  code: "permission_denied",
+                  message: "Access forbidden."
+                }
+  /corporate/ssoToken:
+    post:
+      tags:
+      - Master account
+      summary: Generate SSO token to access admin account
+      description: This endpoint generates an SSO token to authenticate and access the admin account using the endpoint https://account-app.brevo.com/account/login/corporate/sso/[token], where [token] will be replaced by the actual token.
+      parameters:
+        - name: ssoTokenRequestCorporate
+          description: User email of admin account
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ssoTokenRequestCorporate'
+      responses:
+        200:
+          description: Session token
+          schema:
+              $ref: '#/definitions/getSsoToken'
+          examples:
+            application/json:
+                {
+                  "token": "5cadaxxxxxxxxxxxxxxxxxxxx5a179f85a0"
+                }
+        400:
+          description: bad request
+          schema:
+              $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "Invalid email address"
+                }
+        403:
+          description: Current account is not an admin account
+          schema:
+              $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+                {
+                  code: "permission_denied",
+                  message: "Access forbidden."
+                }
+  /corporate/subAccount/ssoToken:
+    post:
+      tags:
+        - Master account
+      summary: Generate SSO token to access sub-account
+      description: This endpoint generates an sso token to authenticate and access a sub-account of the master using the account endpoint https://account-app.brevo.com/account/login/sub-account/sso/[token], where [token] will be replaced by the actual token.
+      parameters:
+        - name: ssoTokenRequest
+          description: Values to generate SSO token for sub-account
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ssoTokenRequest'
+      responses:
+        200:
+          description: Session token
+          schema:
+              $ref: '#/definitions/getSsoToken'
+          examples:
+            application/json:
+                {
+                  "token": "5cadaxxxxxxxxxxxxxxxxxxxx5a179f85a0"
+                }
+        400:
+          description: bad request
+          schema:
+              $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "Invalid sub-account id."
+                }
+        403:
+          description: Current account is not a master account
+          schema:
+              $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+                {
+                  code: "permission_denied",
+                  message: "Access forbidden."
+                }
+  /corporate/masterAccount:
+    get:
+      tags:
+        - Master account
+      summary: Get the details of requested master account
+      description: This endpoint will provide the details of the master account.
+      responses:
+        200:
+          description: Master account details
+          schema:
+            $ref: '#/definitions/masterDetailsResponse'
+          examples:
+            application/json:
+              {
+                "email": "sample@example.com",
+                "companyName": "Corp Sample 1-1",
+                "id": 1003286,
+                "currencyCode": "INR",
+                "timezone": "Europe/Paris",
+                "billingInfo":
+                {
+                  "email": "sample@example.com",
+                  "companyName": "Corp Sample 1-1",
+                  "name":
+                  {
+                    "givenName": "Uday",
+                    "familyName": "Pandit"
+                  },
+                  "address":
+                    {
+                      "streetAddress": "C-92",
+                      "locality": "Pandav Nagar, New Delhi",
+                      "postalCode": "560048",
+                      "stateCode": "UP",
+                      "countryCode": "IN"
+                    }
+                },
+                "planInfo":
+                {
+                    "currencyCode": "INR",
+                    "nextBillingAt": 1637739295,
+                    "price": 2100,
+                    "planPeriod": "month",
+                    "subAccounts": 15,
+                    "features":
+                      [
+                        {
+                          "name": "MULTI_USER",
+                          "unitValue": 1,
+                          "quantity": 10,
+                          "used": 15,
+                          "remaining": 0
+                        },
+                        {
+                          "name": "ADVANCED_REPORTING",
+                          "unitValue": 1,
+                          "quantity": 12,
+                          "used": 1,
+                          "remaining": 11
+                        },
+                        {
+                          "name": "INBOX",
+                          "unitValue": 1,
+                          "quantity": 10,
+                          "used": 10,
+                          "remaining": 0
+                        },
+                        {
+                          "name": "LANDING_PAGE",
+                          "unitValue": 5,
+                          "quantity": 10,
+                          "used": 11,
+                          "remaining": 0
+                        },
+                        {
+                          "name": "RECURRING_CREDITS",
+                          "unitValue": 1,
+                          "quantity": 500,
+                          "used": 1,
+                          "remaining": 499
+                        }
+                      ]
+                }
+              }
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /corporate/subAccount/key:
+    post:
+        tags:
+          - Master account
+        summary: Create an API key for a sub-account
+        description: This endpoint will generate an API v3 key for a sub account
+        parameters:
+          - name: createApiKeyRequest
+            description: Values to generate API key for sub-account
+            in: body
+            required: true
+            schema:
+              $ref: '#/definitions/createApiKeyRequest'
+        responses:
+          201:
+            description: API Key
+            schema:
+              $ref: '#/definitions/createApiKeyResponse'
+            examples:
+              application/json:
+                {
+                  "status": "success",
+                  "key": "xkeysib-21881axxxxxcc92e04-mIrexxxx7z"
+                }
+          400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+            examples:
+              application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "id should be a positive number"
+                }
+  /corporate/subAccount/{id}/applications/toggle:
+    put:
+      tags:
+        - Master account
+      summary: Enable/disable sub-account application(s)
+      description: API endpoint for the Corporate owner to enable/disable applications on the sub-account
+      parameters:
+        - name: id
+          description: Id of the sub-account organization (mandatory)
+          type: integer
+          format: int64
+          in: path
+          required: true
+        - name: toggleApplications
+          description: List of applications to activate or deactivate on a sub-account
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/subAccountAppsToggleRequest'
+      responses:
+        204:
+          description: Sub-account application(s) enabled/disabled
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        403:
+          description: Current account is not a master account
+          schema:
+              $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+                {
+                  code: "permission_denied",
+                  message: "Access forbidden."
+                }
+  /corporate/group:
+    post:
+      tags:
+        - Master account
+      summary: Create a new group of sub-accounts
+      description: This endpoint allows to create a group of sub-accounts
+      parameters:
+      - name: body
+        in: body
+        required: true
+        description: Group details to be created.
+        schema:
+          required:
+          - groupName
+          type: object
+          properties:
+            groupName:
+              type: string
+              description: The name of the group of sub-accounts
+              example: "My group"
+            subAccountIds:
+              items:
+                    type: integer
+                    format: int64
+              type: array
+              description: Pass the list of sub-account Ids to be included in the group
+              example: [234322, 325553, 893432]
+      responses:
+          201:
+            description: Group ID
+            schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+            examples:
+              application/json:
+                {
+                  "id": "659xxxxxxxxxxxxxxxx6ef9c8"
+                }
+          400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+            examples:
+              application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "Invalid request"
+                }
+  /corporate/ip:
+    get:
+      tags:
+      - Master account
+      summary: List of all IPs
+      description: This endpoint allows you to retrieve the list of active IPs on your Admin account
+      responses:
+        200:
+          description: List of all IPs
+          schema: array
+          examples:
+            application/json: "[{ip:\"192.168.1.1\",domain:\"example.com\",transactional:true}]"
+
+  /corporate/subAccount/ip/associate:
+    post:
+      tags:
+        - Master account
+      summary: Associate an IP to sub-accounts
+      description: This endpoint allows to associate an IP to sub-accounts
+      parameters:
+      - name: body
+        in: body
+        required: true
+        description: Ip address association details
+        schema:
+          required:
+          - ip
+          - ids
+          type: object
+          properties:
+            ip:
+              type: string
+              description: IP Address
+              example: "103.11.32.88"
+            ids:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: Pass the list of sub-account Ids to be associated with the IP address
+              example: [234322, 325553, 893432]
+      responses:
+          201:
+            description: IP has been associated with sub-accounts successfully
+            schema:
+                type: object
+            examples:
+              application/json:
+                []
+          400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+            examples:
+              application/json:
+                {
+                  code: "Invalid id.",
+                  message: "Invalid request"
+                }
+  /corporate/subAccount/ip/dissociate:
+    put:
+      tags:
+        - Master account
+      summary: Dissociate an IP from sub-accounts
+      description: This endpoint allows to dissociate an IP from sub-accounts
+      parameters:
+      - name: body
+        in: body
+        required: true
+        description: Ip address dissociation details
+        schema:
+          required:
+          - ip
+          - ids
+          type: object
+          properties:
+            ip:
+              type: string
+              description: IP Address
+              example: "103.11.32.88"
+            ids:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: Pass the list of sub-account Ids to be dissociated from the IP address
+              example: [234322, 325553, 893432]
+      responses:
+          204:
+            description: IP has been dissociated from sub-accounts successfully
+          400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+            examples:
+              application/json:
+                {
+                  code: "Invalid id.",
+                  message: "Invalid request"
+                }
+  /corporate/group/{id}:
+    get:
+      tags:
+        - Master account
+      summary: GET a group details
+      description: This endpoint allows you to retrieve a specific group’s information such as the list of sub-organizations and the user associated with the group.
+      parameters:
+      - name: id
+        in: path
+        type: string
+        description: Id of the group of sub-organization
+        required: true
+      responses:
+        200:
+          description: Group details
+          schema:
+            $ref: '#/definitions/corporateGroupDetailsResponse'
+          examples:
+            application/json:
+              {
+                "group": {
+                  "id": "5f926dba72a405440a4efc97",
+                  "groupName": "My group",
+                  "createdAt": "2024-02-09T06:14:40+00:00"
+                },
+                "sub-accounts": [
+                  {
+                    "id": "7866556",
+                    "companyName": "My sub organization",
+                    "createdAt": "2024-02-09T06:14:40+00:00"
+                  },
+                  {
+                    "id": "6563051",
+                    "companyName": "Your sub organization",
+                    "createdAt": "2024-01-05T03:11:40+00:00"
+                  }
+                ],
+                "users": [
+                  {
+                    "email": "my-user@my-org.com",
+                    "lastName": "Smith",
+                    "firstName": "John"
+                  },
+                  {
+                    "email": "your-user@your-org.com"
+                  }
+                ]
+              }
+    put:
+      tags:
+        - Master account
+      summary: Update a group of sub-accounts
+      description: This endpoint allows you to update a group of sub-accounts
+      parameters:
+      - name: id
+        in: path
+        type: string
+        description: Id of the group
+        required: true
+      - name: body
+        in: body
+        required: true
+        description: Group details to be updated.
+        schema:
+          required:
+          - groupName
+          type: object
+          properties:
+            groupName:
+              type: string
+              description: The name of the group of sub-accounts
+              example: "My group"
+            subAccountIds:
+              items:
+                    type: integer
+                    format: int64
+              type: array
+              description: Pass the list of sub-account Ids to be included in the group
+              example: [234322, 325553, 893432]
+      responses:
+        204:
+          description: Group details updated
+        400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+            examples:
+              application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "Invalid request"
+                }
+    delete:
+      tags:
+        - Master account
+      summary: Delete a group
+      description: This endpoint allows you to delete a group of sub-organizations. When a group is deleted, the sub-organizations are no longer part of this group. The users associated with the group are no longer associated with the group once deleted.
+      parameters:
+        - name: id
+          in: path
+          type: string
+          description: Id of the group
+          required: true
+      responses:
+        204:
+          description: Group deleted
+        400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+            examples:
+              application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "Invalid request"
+                }
+  /corporate/group/unlink/{groupId}/subAccounts:
+    put:
+      tags:
+        - Master account
+      summary: Delete sub-account from group
+      description: This endpoint allows you to remove a sub-organization from a group.
+      parameters:
+      - name: groupId
+        in: path
+        type: string
+        description: Id of the group
+        required: true
+      - name: body
+        in: body
+        required: true
+        description: List of sub-account ids
+        schema:
+          required:
+          - subAccountIds
+          type: object
+          properties:
+            subAccountIds:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: List of sub-account ids
+              example: [423432, 234323, 87678]
+      responses:
+        204:
+          description: SubAccounts removed from the group
+        400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+            examples:
+              application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "subAccountIds should be array of numeric ids only"
+                }
+  /corporate/user/invitation/send:
+    post:
+      tags:
+      - Master account
+      summary: Send invitation to an admin user
+      description: |
+        `This endpoint allows you to invite a member to manage the Admin account
+
+        Features and their respective permissions are as below:
+
+        - `my_plan`:
+          - "all"
+        - `api`:
+          - "none"
+        - `user_management`:
+          - "all"
+        - `app_management` | Not available in ENTv2:
+          - "all"
+        - `sub_organization_groups`
+          - "create"
+          - "edit_delete"
+        - `create_sub_organizations`
+          - "all"
+        - `manage_sub_organizations`
+          - "all"
+        - `analytics`
+          - "download_data"
+          - "create_alerts"
+          - "my_looks"
+          - "explore_create"
+        - `security`
+          - "all"
+
+        **Note**:
+        - If `all_features_access: false` then only privileges are required otherwise if `true` then it's assumed that all permissions will be there for the invited admin user.
+      operationId: inviteAdminUser
+      parameters:
+        - name: sendInvitation
+          description: Payload to send an invitation
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/inviteAdminUser'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/inviteAdminUser'
+          examples:
+            application/json:
+              {
+                "id": "2b4xxxxxxxxxxxxxxxxxxxxxda4",
+              }
+        '400':
+          description: Bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /corporate/user/invitation/{action}/{email}:
+    put:
+      tags:
+        - Master account
+      summary: Resend / cancel admin user invitation
+      description: |
+        This endpoint will allow the user to:
+        - Resend an admin user invitation
+        - Cancel an admin user invitation
+      parameters:
+        - name: action
+          in: path
+          type: string
+          description: Action to be performed (cancel / resend)
+          required: true
+        - name: email
+          in: path
+          type: string
+          description: Email address of the recipient
+          required: true
+      responses:
+        200:
+            description: Response of the action performed
+            schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+            examples:
+              application/json:
+                {
+                  "message": "Invitation resent successfully"
+                }
+        400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+            examples:
+              application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "Invitation not found"
+                }
+  /corporate/user/revoke/{email}:
+    delete:
+      tags:
+      - Master account
+      summary: Revoke an admin user
+      description: This endpoint allows to revoke/remove an invited member of your Admin account
+      parameters:
+        - name: email
+          description: Email of the invited user
+          in: path
+          required: true
+          type: string
+      responses:
+        204:
+          description: User revoked
+        400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+            examples:
+              application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "Invalid request"
+                }
+  /corporate/invited/users:
+    get:
+      tags:
+      - Master account
+      summary: Get the list of all admin users
+      description: This endpoint allows you to list all Admin users of your Admin account. You can filter users by type (active or pending) and paginate results using offset and limit.
+      operationId: getCorporateInvitedUsersList
+      parameters:
+      - name: type
+        description: User type (active | pending). This is required if offset is provided for limited result.
+        in: query
+        schema:
+          type: string
+      - name: offset
+        description: Page number for the result set. This is optional, default value will be the 1st page.
+        in: query
+        schema:
+          type: integer
+      - name: limit
+        description: Number of users to be displayed on each page. This is optional, the default limit is 20, but max allowed limit is 100.
+        in: query
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: list of all admin users
+          schema:
+            $ref: '#/definitions/getCorporateInvitedUsersList'
+          examples:
+            application/json:
+                {
+                  "users": [
+                    {
+                      "groups": [
+                        {
+                          "id": 65b1f22c09d6ed67ef1cd123,
+                          "name": "Test Group1"
+                        },
+                        {
+                          "id": 43b1f16c09db4d67af1cd342,
+                          "name": "Test Group2"
+                        }
+                      ],
+                      "email": "master-user2@company.com",
+                      "is_owner": false,
+                      "status": "active",
+                      "feature_access": {
+                        "user_management": ["none"],
+                        "api_keys": ["none"],
+                        "my_plan": ["all"],
+                        "apps_management": ["all"],
+                        "sub_organization_groups": ["create", "edit_delete"],
+                        "create_sub_organizations": ["all"],
+                        "manage_sub_organizations": ["all"],
+                        "analytics": ["download_data", "create_alerts"],
+                        "security": ["all"]
+                      }
+                    },
+                    {
+                      "groups": [],
+                      "email": "master-user3@company.com",
+                      "is_owner": false,
+                      "status": "active",
+                      "feature_access": {
+                        "user_management": ["all"],
+                        "api_keys": ["none"],
+                        "my_plan": ["all"],
+                        "apps_management": ["all"],
+                        "sub_organization_groups": ["edit_delete"],
+                        "create_sub_organizations": ["all"],
+                        "manage_sub_organizations": ["all"],
+                        "analytics": ["create_alerts"],
+                        "security": ["none"]
+                      }
+                    }
+                  ]
+                }
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /corporate/user/{email}/permissions:
+    get:
+      tags:
+      - Master account
+      summary: Check admin user permissions
+      description: This endpoint will provide the list of admin user permissions
+      operationId: getCorporateUserPermission
+      parameters:
+        - name: email
+          description: Email of the invited user
+          in: path
+          required: true
+          type: string
+      responses:
+        200:
+          description: List of user's permissions
+          schema:
+              $ref: '#/definitions/getCorporateUserPermission'
+          examples:
+            application/json:
+                {
+                  "email": "test@email.com",
+                  "status": "active",
+                  "groups": [
+                    {
+                      "id": "6543ab3667ffbb00142e4486",
+                      "name": "Support"
+                    },
+                    {
+                      "id": "174bab366732bbce142e4412",
+                      "name": "Technical"
+                    }
+                  ],
+                  "feature_access": {
+                    "api_keys": ["all"],
+                    "my_plan": ["all"],
+                    "user_management": ["none"],
+                    "apps_management": ["all"],
+                    "sub_organization_groups": ["create", "edit_delete"],
+                    "create_sub_organizations": ["all"],
+                    "manage_sub_organizations": ["all"],
+                    "analytics": ["download_data", "create_alerts"],
+                    "security": ["all"]
+                  }
+                }
+        400:
+          description: bad request
+          schema:
+              $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "Invalid email address"
+                }
+    put:
+      tags:
+        - Master account
+      summary: Change admin user permissions
+      description: This endpoint will allow you to change the permissions of Admin users of your Admin account
+      parameters:
+      - name: email
+        in: path
+        description: Email address of Admin user
+        required: true
+        type: string
+      - name: body
+        in: body
+        required: true
+        description: Values to update an admin user permissions
+        schema:
+          example:
+              all_features_access: false
+              privileges:
+                - feature: user_management
+                  permissions: ["all"]
+                - feature: api
+                  permissions: ["all"]
+                - feature: my_plan
+                  permissions: ["none"]
+                - feature: apps_management
+                  permissions: ["all"]
+                - feature: create_sub_organizations
+                  permissions: ["all"]
+                - feature: sub_organization_groups
+                  permissions: ["create","edit_delete"]
+                - feature: manage_sub_organizations
+                  permissions: ["all"]
+                - feature: security
+                  permissions: ["none"]
+                - feature: analytics
+                  permissions: ["create_alerts","download_data","my_looks","explore_create"]
+          required:
+          - all_features_access
+          - privileges
+          type: object
+          properties:
+            all_features_access:
+              description: All access to the features
+              type: boolean
+              example: true
+              enum:
+                - true
+                - false
+            privileges:
+              type: array
+              items:
+                type: object
+                description: Permission on features
+                properties:
+                  feature:
+                    type: string
+                    description: feature name
+                    enum:
+                      - user_management
+                      - api
+                      - my_plan
+                      - apps_management
+                      - analytics
+                      - sub_organization_groups
+                      - create_sub_organizations
+                      - manage_sub_organizations
+                      - security
+                    example: user_management
+                  permissions:
+                    type: array
+                    description: Permission for the feature
+                    items:
+                      type: string
+                      enum:
+                        - all
+                        - none
+                        - create
+                        - edit_delete
+                        - create_alerts
+                        - download_data
+                        - my_looks
+                        - explore_create
+                    example: ["all"]
+      responses:
+        204:
+          description: User permissions has been modified
+        400:
+          description: bad request
+          schema:
+              $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+                {
+                  code: "invalid_parameter",
+                  message: "Invalid email"
+                }
+  /corporate/groups:
+    get:
+      tags:
+      - Master account
+      summary: Get the list of groups
+      description: This endpoint allows you to list all groups created on your Admin account.
+      operationId: getSubAccountGroups
+      responses:
+        '200':
+          description: list of all the sub-account groups
+          schema:
+            type: array
+            required:
+              - id
+              - groupName
+            items:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: Unique id of the group
+                groupName:
+                  type: string
+                  description: The name of the group of sub-accounts
+          examples:
+            application/json:
+                [
+                  {
+                    "id": "d3b142c709d6ed67ef1cd903",
+                    "groupName": "My group 1"
+                  },
+                  {
+                    "id": "a5b192a709d6ed67ef8fd922",
+                    "groupName": "My group 2"
+                  },
+                  {
+                    "id": "bbb142c709d6ed67ef1cd910",
+                    "groupName": "My group 3"
+                  }
+                ]
+        '400':
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /companies:
+    get:
+      tags:
+        - Companies
+      summary: Get all companies
+      parameters:
+      - name: filters
+        in: query
+        type: string
+        description: Filter by attrbutes. If you have filter for owner on your side please send it as {"attributes.owner":"5b1a17d914b73d35a76ca0c7"}
+      - name: linkedContactsIds
+        in: query
+        type: integer
+        format: int64
+        description: Filter by linked contacts ids
+      - name: linkedDealsIds
+        in: query
+        type: string
+        format: objectID
+        description: Filter by linked deals ids
+      - name: modifiedSince
+        description: Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
+        in: query
+        required: false
+        type: string
+      - name: createdSince
+        description: Filter (urlencoded) the contacts created after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
+        in: query
+        required: false
+        type: string
+      - name: page
+        in: query
+        type: integer
+        format: int64
+        description: Index of the first document of the page
+      - name: limit
+        in: query
+        type: integer
+        default: 50
+        format: int64
+        description: Number of documents per page
+      - name: sort
+        in: query
+        type: string
+        enum:
+        -  asc
+        -  desc
+        description: Sort the results in the ascending/descending order. Default order is **descending** by creation if `sort` is not passed
+      - name: sortBy
+        in: query
+        type: string
+        description: The field used to sort field names.
+      responses:
+        200:
+          description: Returns companies list with filters
+          schema:
+            $ref: '#/definitions/CompaniesList'
+        400:
+          description: Returned when query params are invalid
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            response:
+              value:
+                "message": "Not valid data."
+    post:
+      tags:
+        - Companies
+      summary: Create a company
+      parameters:
+      - name: body
+        in: body
+        required: true
+        description: Company create data.
+        schema:
+          required:
+          - name
+          properties:
+            name:
+              type: string
+              description: Name of company
+              example: "company"
+            attributes:
+              type: object
+              description: |
+                Attributes for company creation
+                To assign owner of a Company you can send `owner` and utilize the account email or ID.
+              example: {
+                             "domain": "https://example.com",
+                             "industry": "Fabric",
+                             "owner": "60e68d60582a3b006f524197"
+              }
+            countryCode:
+              type: integer
+              format: int64
+              description: Country code if phone_number is passed in attributes.
+              example: 91
+            linkedContactsIds:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: Contact ids to be linked with company
+              example: [ 1, 2, 3]
+            linkedDealsIds:
+              items:
+                type: string
+                format: objectID
+              type: array
+              description: Deal ids to be linked with company
+              example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+          type: object
+      responses:
+        200:
+          description: Created new company
+          schema:
+            required:
+            - id
+            type: object
+            description: Created company id
+            properties:
+              id:
+                type: string
+                description: Unique company id
+                example: "61a5cd07ca1347c82306ad06"
+        400:
+          description: Returned when invalid data posted
+  /companies/{id}:
+    get:
+      tags:
+        - Companies
+      summary: Get a company
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      responses:
+        200:
+          description: Returns the company by id
+          schema:
+            $ref: '#/definitions/Company'
+        400:
+          description: Returned when company id is invalid
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route company id is not valid."
+              }
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+    delete:
+      tags:
+        - Companies
+      summary: Delete a company
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      responses:
+        204:
+          description: Returned when item deleted
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route company id is not valid."
+              }
+        404:
+          description: Returned when company id is not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+    patch:
+      tags:
+        - Companies
+      summary: Update a company
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      - name: body
+        in: body
+        required: true
+        description: Updated company details.
+        schema:
+          properties:
+            name:
+              type: string
+              description: Name of company
+              example: "company"
+            attributes:
+              type: object
+              description: Attributes for company update
+              example: {
+                "category": "label_2",
+                      "domain": "xyz",
+                      "date": "2022-05-04T00:00:00+05:30",
+                      "industry": "flipkart",
+                      "number_of_contacts": 1,
+                      "number_of_employees": 100,
+                      "owner": "5b1a17d914b73d35a76ca0c7",
+                      "phone_number": "81718441912",
+                      "revenue": 10000.34222
+              }
+            countryCode:
+              type: integer
+              format: int64
+              description: Country code if phone_number is passed in attributes.
+              example: 91
+            linkedContactsIds:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: Warning - Using PATCH on linkedContactIds replaces the list of linked contacts. Omitted IDs will be removed.
+              example: [ 1, 2, 3]
+            linkedDealsIds:
+              items:
+                type: string
+                format: objectID
+              type: array
+              description: Warning - Using PATCH on linkedDealsIds replaces the list of linked contacts. Omitted IDs will be removed.
+              example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+          type: object
+      responses:
+        200:
+          description: Company updated successfully
+          schema:
+            $ref: '#/definitions/Company'
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route company id is not valid."
+              }
+        404:
+          description: Returned when company id is not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+  /crm/attributes/companies:
+    get:
+      tags:
+        - Companies
+      summary: Get company attributes
+      responses:
+        200:
+          description: Returns list of company attributes
+          schema:
+            $ref: '#/definitions/CompanyAttributes'
+  /companies/link-unlink/{id}:
+    patch:
+      tags:
+        - Companies
+      summary: Link and Unlink company with contacts and deals
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      - name: body
+        in: body
+        required: true
+        description: Linked / Unlinked contacts and deals ids.
+        schema:
+          properties:
+            linkContactIds:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: Contact ids for contacts to be linked with company
+              example: [ 1, 2, 3]
+            unlinkContactIds:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: Contact ids for contacts to be unlinked from company
+              example: [ 4, 5, 6]
+            linkDealsIds:
+              items:
+                type: string
+              type: array
+              description: Deals ids for deals to be linked with company
+              example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+            unlinkDealsIds:
+              items:
+                type: string
+              type: array
+              description: Deals ids for deals to be unlinked from company
+              example: [ "61a5ce58c5d4795761045994", "61a5ce58c5d479576104595" , "61a5ce58c5d4795761045996"]
+          type: object
+      responses:
+        204:
+          description: Returns list of company attributes
+        400:
+          description: Returned when query params are invalid
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            response:
+              value:
+                "message": "Not valid data."
+  /crm/attributes:
+    post:
+      tags:
+        - Companies
+        - Deals
+      summary: Create a deal/company attribute
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: Attribute creation data for company
+          schema:
+            required:
+              - label
+              - attributeType
+              - objectType
+            properties:
+              label:
+                type: string
+                description: The label for the attribute (max 50 characters, cannot be empty)
+                example: "Attribute Label"
+              attributeType:
+                type: string
+                description: The type of attribute (must be one of the defined enums)
+                enum:
+                  - text
+                  - user
+                  - number
+                  - single-select
+                  - date
+                  - boolean
+                  - multi-choice
+                example: "single-select"
+              description:
+                type: string
+                description: A description of the attribute
+                example: "This is a sample attribute description."
+              optionsLabels:
+                type: array
+                items:
+                  type: string
+                description: Options for multi-choice or single-select attributes
+                example: ["Option 1", "Option 2", "Option 3"]
+              objectType:
+                type: string
+                description: The type of object the attribute belongs to (prefilled with `companies`or `deal`, mandatory)
+                example: deal,companies
+                enum:
+                  - companies
+                  - deals
+            type: object
+      responses:
+        200:
+          description: Created new attribute
+          schema:
+            type: object
+            required:
+              - id
+            properties:
+              id:
+                type: string
+                description: Unique ID of the created attribute
+                example: "61a5cd07ca1347c82306ad07"
+        400:
+          description: Returned when invalid data is posted
+  /companies/import:
+    post:
+      tags:
+        - Companies
+      summary: Import companies(creation and updation)
+      description: Import companies from a CSV file with mapping options.
+      consumes:
+        - multipart/form-data
+      parameters:
+      - in: formData
+        name: file
+        required: true
+        type: file
+        format: binary
+        description: |
+                    The CSV file to upload.The file should have the first row as the mapping attribute. Some default attribute names are
+                    (a) company_id [brevo mongoID to update deals]
+                    (b) associated_contact
+                    (c) associated_deal
+                    (f) any other attribute with internal name
+      - in: formData
+        name: mapping
+        description: |
+          The mapping options in JSON format.
+            json
+             {
+                "link_entities": true, // Determines whether to link related entities during the import process
+                "unlink_entities": false, //Determines whether to unlink related entities during the import process.
+                "update_existing_records": true, // Determines whether to update based on company ID or treat every row as create
+                "unset_empty_attributes": false // Determines whether unset a specific attribute during update if values input is blank
+                "use_company_identifier": false // Determines whether to use company name as identifier
+              }
+
+        type: string
+        required: true
+      responses:
+        200:
+          description: Successfully imported companies
+          schema:
+            type: object
+            properties:
+              processId:
+                type: integer
+                description: The ID of the import process
+                example: 50
+        400:
+          description: Bad request
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: "Bad request: With reason"
+  /crm/pipeline/details:
+    get:
+      tags:
+        - Deals
+      summary: Get pipeline stages
+      description: This endpoint is deprecated. Prefer /crm/pipeline/details/{pipelineID} instead.
+      deprecated: true
+      responses:
+        200:
+          description: Returns list of pipeline stages
+          schema:
+            $ref: '#/definitions/Pipeline'
+  /crm/pipeline/details/{pipelineID}:
+    get:
+      tags:
+        - Deals
+      summary: Get a pipeline
+      parameters:
+      - name: pipelineID
+        in: path
+        required: true
+        type: string
+      responses:
+        200:
+          description: Returns pipeline and its details
+          schema:
+            $ref: '#/definitions/Pipelines'
+        400:
+          description: Returned when pipeline id is invalid or does not exist
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Pipeline not found"
+              }
+  /crm/pipeline/details/all:
+    get:
+      tags:
+        - Deals
+      summary: Get all pipelines
+      responses:
+        200:
+          description: Returns list of pipelines and its details
+          schema:
+            $ref: '#/definitions/Pipelines'
+        400:
+          description: Returned when pipeline id is invalid or does not exist
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Pipeline not found"
+              }
+  /crm/attributes/deals:
+    get:
+      tags:
+        - Deals
+      summary: Get deal attributes
+      responses:
+        200:
+          description: Returns list of deal attributes
+          schema:
+            $ref: '#/definitions/DealAttributes'
+  /crm/deals:
+    get:
+      tags:
+        - Deals
+      summary: Get all deals
+      parameters:
+      - name: filters[attributes.deal_name]
+        in: query
+        type: string
+        description: Filter by attributes. If you have a filter for the owner on your end, please send it as filters[attributes.deal_owner] and utilize the account email for the filtering.
+      - name: filters[linkedCompaniesIds]
+        in: query
+        type: string
+        description: Filter by linked companies ids
+      - name: filters[linkedContactsIds]
+        in: query
+        type: string
+        description: Filter by linked companies ids
+      - name: modifiedSince
+        description: Filter (urlencoded) the contacts modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
+        in: query
+        required: false
+        type: string
+      - name: createdSince
+        description: Filter (urlencoded) the contacts created after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
+        in: query
+        required: false
+        type: string
+      - name: offset
+        in: query
+        type: integer
+        format: int64
+        description: Index of the first document of the page
+      - name: limit
+        in: query
+        type: integer
+        default: 50
+        format: int64
+        description: Number of documents per page
+      - name: sort
+        in: query
+        type: string
+        enum:
+        -  asc
+        -  desc
+        description: Sort the results in the ascending/descending order. Default order is **descending** by creation if `sort` is not passed
+      - name: sortBy
+        in: query
+        type: string
+        description: The field used to sort field names.
+      responses:
+        200:
+          description: Returns deals list with filters
+          schema:
+            $ref: '#/definitions/DealsList'
+        400:
+          description: Returned when query params are invalid
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            response:
+              value:
+                "message": "Not valid data."
+    post:
+      tags:
+        - Deals
+      summary: Create a deal
+      parameters:
+      - name: body
+        in: body
+        required: true
+        description: Deal create data.
+        schema:
+          required:
+          - name
+          properties:
+            name:
+              type: string
+              description: Name of deal
+              example: "Deal: Connect with company"
+            attributes:
+              type: object
+              description: |
+                Attributes for deal creation
+
+                To assign owner of a Deal you can send attributes.deal_owner and utilize the account email or ID.
+
+                If you want to create a deal on a specific pipeline and stage you can use the following attributes `pipeline` and `deal_stage`.
+
+                Pipeline and deal_stage are ids you can fetch using this endpoint `/crm/pipeline/details/{pipelineID}`
+              example: {
+                deal_owner: "6093d2425a9b436e9519d034",
+                amount: 12
+              }
+            linkedContactsIds:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: Contact ids to be linked with deal
+              example: [ 1, 2, 3]
+            linkedCompaniesIds:
+              items:
+                type: string
+                format: objectID
+              type: array
+              description: Company ids to be linked with deal
+              example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+          type: object
+      responses:
+        201:
+          description: Created new Deal
+          schema:
+            required:
+            - id
+            type: object
+            description: Created deal id
+            properties:
+              id:
+                type: string
+                description: Unique deal id
+                example: "61a5cd07ca1347c82306ad06"
+        400:
+          description: Returned when invalid data posted
+  /crm/deals/{id}:
+    get:
+      tags:
+        - Deals
+      summary: Get a deal
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      responses:
+        200:
+          description: Returns the deal by id
+          schema:
+            $ref: '#/definitions/Deal'
+        400:
+          description: Returned when task id is invalid
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid."
+              }
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+    delete:
+      tags:
+        - Deals
+      summary: Delete a deal
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      responses:
+        204:
+          description: Returned when item deleted
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid."
+              }
+        404:
+          description: Returned when deal id is not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+    patch:
+      tags:
+        - Deals
+      summary: Update a deal
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      - name: body
+        in: body
+        required: true
+        description: Updated deal details.
+        schema:
+          properties:
+            name:
+              type: string
+              description: Name of deal
+              example: "Deal: Connect with client"
+            attributes:
+              type: object
+              description: |
+                Attributes for deal update
+
+                To assign owner of a Deal you can send attributes.deal_owner and utilize the account email or ID.
+
+                If you wish to update the pipeline of a deal you need to provide the `pipeline` and the `deal_stage`.
+
+                Pipeline and deal_stage are ids you can fetch using this endpoint `/crm/pipeline/details/{pipelineID}`
+              example: {
+                deal_owner: "6093d2425a9b436e9519d034",
+                amount: 12
+              }
+            linkedContactsIds:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: Warning - Using PATCH on linkedContactIds replaces the list of linked contacts. Omitted IDs will be removed.
+
+              example: [ 1, 2, 3]
+            linkedCompaniesIds:
+              items:
+                type: string
+                format: objectID
+              type: array
+              description: Warning - Using PATCH on linkedCompaniesIds replaces the list of linked contacts. Omitted IDs will be removed.
+
+              example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+          type: object
+      responses:
+        204:
+          description: Deal updated successfully
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid."
+              }
+        404:
+          description: Returned when deal id is not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+  /crm/deals/link-unlink/{id}:
+    patch:
+      tags:
+        - Deals
+      summary: Link and Unlink a deal with contacts and companies
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      - name: body
+        in: body
+        required: true
+        description: Linked / Unlinked contacts and companies ids.
+        schema:
+          properties:
+            linkContactIds:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: Contact ids for contacts to be linked with deal
+              example: [ 1, 2, 3]
+            unlinkContactIds:
+              items:
+                type: integer
+                format: int64
+              type: array
+              description: Contact ids for contacts to be unlinked from deal
+              example: [ 4, 5, 6]
+            linkCompanyIds:
+              items:
+                type: string
+              type: array
+              description: Company ids to be linked with deal
+              example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+            unlinkCompanyIds:
+              items:
+                type: string
+              type: array
+              description: Company ids to be unlinked from deal
+              example: [ "61a5ce58c5d4795761045994", "61a5ce58c5d479576104595" , "61a5ce58c5d4795761045996"]
+          type: object
+      responses:
+        204:
+          description: Successfully linked/unlinked contacts/companies with the deal.
+        400:
+          description: Returned when query params are invalid or invalid data provided in request.
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            response:
+              value:
+                "message": "Not valid data."
+  /crm/deals/import:
+    post:
+      tags:
+        - Deals
+      summary: Import deals(creation and updation)
+      description: Import deals from a CSV file with mapping options.
+      consumes:
+        - multipart/form-data
+      parameters:
+      - in: formData
+        name: file
+        required: true
+        type: file
+        format: binary
+        description: |
+                    The CSV file to upload.The file should have the first row as the mapping attribute. Some default attribute names are
+                    (a) deal_id [brevo mongoID to update deals]
+                    (b) associated_contact
+                    (c) associated_company
+                    (f) any other attribute with internal name
+      - in: formData
+        name: mapping
+        description: |
+          The mapping options in JSON format.
+            json
+             {
+                "link_entities": true, // Determines whether to link related entities during the import process
+                "unlink_entities": false, //Determines whether to unlink related entities during the import process.
+                "update_existing_records": true, // Determines whether to update based on deal ID or treat every row as create
+                "unset_empty_attributes": false // Determines whether unset a specific attribute during update if values input is blank
+              }
+
+        type: string
+        required: true
+      responses:
+        200:
+          description: Successfully imported deals
+          schema:
+            type: object
+            properties:
+              processId:
+                type: integer
+                description: The ID of the import process
+                example: 50
+        400:
+          description: Bad request
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: "Bad request: With reason"
+
+  /crm/tasktypes:
+    get:
+      tags:
+        - Tasks
+      summary: Get all task types
+      responses:
+        200:
+          description: Returns all the Task types
+          schema:
+            $ref: '#/definitions/TaskTypes'
+  /crm/tasks:
+    get:
+      tags:
+        - Tasks
+      summary: Get all tasks
+      parameters:
+      - name: filter[type]
+        in: query
+        type: string
+        description: Filter by task type (ID)
+      - name: filter[status]
+        in: query
+        type: string
+        enum:
+          - done
+          - undone
+        description: Filter by task status
+      - name: filter[date]
+        in: query
+        type: string
+        enum:
+          - overdue
+          - today
+          - tomorrow
+          - week
+          - range
+        description: Filter by date
+      - name: filter[assignTo]
+        in: query
+        type: string
+        description: Filter by the "assignTo" ID. You can utilize account emails for the "assignTo" attribute.
+      - name: filter[contacts]
+        in: query
+        type: string
+        description: Filter by contact ids
+      - name: filter[deals]
+        in: query
+        type: string
+        description: Filter by deals ids
+      - name: filter[companies]
+        in: query
+        type: string
+        description: Filter by companies ids
+      - name: dateFrom
+        in: query
+        type: integer
+        description: dateFrom to date range filter type (timestamp in milliseconds)
+      - name: dateTo
+        in: query
+        type: integer
+        description: dateTo to date range filter type (timestamp in milliseconds)
+      - name: offset
+        in: query
+        type: integer
+        format: int64
+        description: Index of the first document of the page
+      - name: limit
+        in: query
+        type: integer
+        default: 50
+        format: int64
+        description: Number of documents per page
+      - name: sort
+        in: query
+        type: string
+        enum:
+        -  asc
+        -  desc
+        description: Sort the results in the ascending/descending order. Default order is **descending** by creation if `sort` is not passed
+      - name: sortBy
+        in: query
+        type: string
+        description: The field used to sort field names.
+      responses:
+        200:
+          description: Returns task list with filters
+          schema:
+            $ref: '#/definitions/TaskList'
+        400:
+          description: Returned when query params are invalid
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            response:
+              value:
+                "message": "Not valid data."
+    post:
+      tags:
+        - Tasks
+      summary: Create a task
+      parameters:
+      - name: body
+        in: body
+        required: true
+        description: Task name.
+        schema:
+          required:
+          - name
+          - taskTypeId
+          - date
+          properties:
+            name:
+              type: string
+              description: Name of task
+              example: "Task: Connect with client"
+            duration:
+              type: integer
+              description: Duration of task in milliseconds [1 minute = 60000 ms]
+              example: 600000
+              format: int64
+              minimum: 0
+            taskTypeId:
+              type: string
+              description: Id for type of task e.g Call / Email / Meeting etc.
+              example: "61a5cd07ca1347c82306ad09"
+            date:
+              type: string
+              format: date-time
+              example: "2021-11-01T17:44:54.668Z"
+              description: Task due date and time
+            notes:
+              type: string
+              description: Notes added to a task
+              example: "In communication with client for resolution of queries."
+            done:
+              type: boolean
+              description: Task marked as done
+              example: false
+            assignToId:
+              type: string
+              description: To assign a task to a user you can use either the account email or ID.
+              example: "5faab4b7f195bb3c4c31e62a"
+            contactsIds:
+              items:
+                type: integer
+              type: array
+              description: Contact ids for contacts linked to this task
+              example: [ 1, 2, 3]
+            dealsIds:
+              items:
+                type: string
+              type: array
+              description: Deal ids for deals a task is linked to
+              example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+            companiesIds:
+              items:
+                type: string
+              type: array
+              description: Companies ids for companies a task is linked to
+              example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+            reminder:
+              $ref: '#/definitions/TaskReminder'
+          type: object
+      responses:
+        201:
+          description: Created new task
+          schema:
+            required:
+            - id
+            type: object
+            description: Task Details
+            properties:
+              id:
+                type: string
+                description: Unique task id
+                example: "61a5cd07ca1347c82306ad06"
+        400:
+          description: Returned when invalid data posted
+  /crm/tasks/{id}:
+    get:
+      tags:
+        - Tasks
+      summary: Get a task
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      responses:
+        200:
+          description: Returns the Task by id
+          schema:
+            $ref: '#/definitions/Task'
+        400:
+          description: Returned when task id is invalid
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid."
+              }
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+    delete:
+      tags:
+        - Tasks
+      summary: Delete a task
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      responses:
+        204:
+          description: Returned when item deleted
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid."
+              }
+        404:
+          description: Returned when task id is not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+    patch:
+      tags:
+        - Tasks
+      summary: Update a task
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      - name: body
+        in: body
+        required: true
+        description: Updated task details.
+        schema:
+          properties:
+            name:
+              type: string
+              description: Name of task
+              example: "Task: Connect with client"
+            duration:
+              type: integer
+              description: Duration of task in milliseconds [1 minute = 60000 ms]
+              example: 600000
+            taskTypeId:
+              type: string
+              description: Id for type of task e.g Call / Email / Meeting etc.
+              example: "61a5cd07ca1347c82306ad09"
+            date:
+              type: string
+              format: date-time
+              example: "2021-11-01T17:44:54.668Z"
+              description: Task date/time
+            notes:
+              type: string
+              description: Notes added to a task
+              example: "In communication with client for resolution of queries."
+            done:
+              type: boolean
+              description: Task marked as done
+              example: false
+            assignToId:
+              type: string
+              description: To assign a task to a user you can use either the account email or ID.
+              example: "5faab4b7f195bb3c4c31e62a"
+            contactsIds:
+              items:
+                type: integer
+              type: array
+              description: Contact ids for contacts linked to this task
+              example: [ 1, 2, 3]
+            dealsIds:
+              items:
+                type: string
+              type: array
+              description: Deal ids for deals a task is linked to
+              example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+            companiesIds:
+              items:
+                type: string
+              type: array
+              description: Companies ids for companies a task is linked to
+              example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+          type: object
+      responses:
+        204:
+          description: Task updated successfully
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid."
+              }
+        404:
+          description: Returned when task id is not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+  /crm/notes:
+    get:
+      tags:
+        - Notes
+      summary: Get all notes
+      parameters:
+      - name: entity
+        in: query
+        type: string
+        enum:
+          - companies
+          - deals
+          - contacts
+        description: Filter by note entity type
+      - name: entityIds
+        in: query
+        type: string
+        description: Filter by note entity IDs
+      - name: dateFrom
+        in: query
+        type: integer
+        description: dateFrom to date range filter type (timestamp in milliseconds)
+      - name: dateTo
+        in: query
+        type: integer
+        description: dateTo to date range filter type (timestamp in milliseconds)
+      - name: offset
+        in: query
+        type: integer
+        format: int64
+        description: Index of the first document of the page
+      - name: limit
+        in: query
+        type: integer
+        default: 50
+        format: int64
+        description: Number of documents per page
+      - name: sort
+        in: query
+        type: string
+        enum:
+        -  asc
+        -  desc
+        description: Sort the results in the ascending/descending order. Default order is **descending** by creation if `sort` is not passed
+      responses:
+        200:
+          description: Returns notes list with filters
+          schema:
+            $ref: '#/definitions/NoteList'
+        400:
+          description: Returned when query params are invalid
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            response:
+              value:
+                "message": "Not valid data."
+    post:
+      tags:
+        - Notes
+      summary: Create a note
+      parameters:
+      - name: body
+        in: body
+        required: true
+        description: Note data to create a note.
+        schema:
+          $ref: "#/definitions/NoteData"
+      responses:
+        200:
+          description: Created new note
+          schema:
+            $ref: '#/definitions/NoteId'
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Not valid data."
+              }
+        415:
+          description: Format is not supported
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "The format not supported for deserialization."
+              }
+  /crm/notes/{id}:
+    get:
+      tags:
+        - Notes
+      summary: Get a note
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: Note ID to get
+      responses:
+        200:
+          description: Returns the Note by id
+          schema:
+            $ref: '#/definitions/Note'
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid."
+              }
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+    patch:
+      tags:
+        - Notes
+      summary: Update a note
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: Note ID to update
+      - name: body
+        in: body
+        required: true
+        description: Note data to update a note
+        schema:
+          $ref: "#/definitions/NoteData"
+      responses:
+        204:
+          description: Note updated successfully
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Not valid data."
+              }
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+        415:
+          description: Format is not supported
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "The format not supported for deserialization."
+              }
+    delete:
+      tags:
+        - Notes
+      summary: Delete a note
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+        description: Note ID to delete
+      responses:
+        204:
+          description: Returned when item deleted
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid."
+              }
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+  /crm/files:
+    get:
+      tags:
+        - Files
+      summary: Get all files
+      parameters:
+      - name: entity
+        in: query
+        type: string
+        required: false
+        enum:
+          - companies
+          - deals
+          - contacts
+        description: Filter by file entity type
+      - name: entityIds
+        in: query
+        type: string
+        description: Filter by file entity IDs
+        required: false
+      - name: dateFrom
+        in: query
+        type: integer
+        description: dateFrom to date range filter type (timestamp in milliseconds)
+        required: false
+      - name: dateTo
+        in: query
+        type: integer
+        description: dateTo to date range filter type (timestamp in milliseconds)
+        required: false
+      - name: offset
+        in: query
+        type: integer
+        format: int64
+        description: Index of the first document of the page
+        required: false
+      - name: limit
+        in: query
+        type: integer
+        default: 50
+        format: int64
+        description: Number of documents per page
+        required: false
+      - name: sort
+        in: query
+        type: string
+        enum:
+        -  asc
+        -  desc
+        description: Sort the results in the ascending/descending order. Default order is **descending** by creation if `sort` is not passed
+        required: false
+      responses:
+        200:
+          description: Returns files list with filters
+          schema:
+            $ref: '#/definitions/FileList'
+        400:
+          description: Returned when query params are invalid
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Not valid data."
+              }
+    post:
+      tags:
+        - Files
+      summary: Upload a file
+      consumes:
+        - multipart/form-data
+      parameters:
+      - in: formData
+        name: file
+        required: true
+        type: file
+        description: File data to create a file.
+      - in: formData
+        name: dealId
+        description: Deal id linked to a file
+        type: string
+      - in: formData
+        name: contactId
+        description: Contact id linked to a file
+        type: integer
+        format: int64
+      - in: formData
+        name: companyId
+        description: Company id linked to a file
+        type: string
+      responses:
+        201:
+          description: Returns the created File with additional details
+          schema:
+            $ref: '#/definitions/FileData'
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Invalid deals ids format."
+              }
+  /crm/files/{id}:
+    get:
+      tags:
+        - Files
+      summary: Download a file
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+        description: File id to download.
+      responses:
+        200:
+          description: Returns downloadable file link. Valid for next 5 minutes only.
+          schema:
+            $ref: '#/definitions/FileDownloadableLink'
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid"
+              }
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+    delete:
+      tags:
+        - Files
+      summary: Delete a file
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+        description: File id to delete.
+      responses:
+        204:
+          description: Returned when file is deleted.
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid"
+              }
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+  /crm/files/{id}/data:
+    get:
+      tags:
+        - Files
+      summary: Get file details
+      parameters:
+      - in: path
+        name: id
+        required: true
+        type: string
+        description: File id to get file data.
+      responses:
+        200:
+          description: Returned when file is found.
+          schema:
+            $ref: '#/definitions/FileData'
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Route attribute id is not valid"
+              }
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+          examples:
+            application/json:
+              {
+                "message": "Document not found"
+              }
+  /conversations/messages:
+    post:
+      tags:
+        - Conversations
+      summary: Send a message as an agent
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: Message fields.
+          schema:
+            type: object
+            required:
+              - visitorId
+              - text
+            properties:
+              visitorId:
+                type: string
+                description: visitor’s ID received <a href="https://developers.brevo.com/docs/conversations-webhooks">from a webhook</a> or generated by you to <a href="https://developers.brevo.com/docs/customize-the-widget#identifying-existing-users">bind existing user account to Conversations</a>
+                example: kZMvWhf8npAu3H6qd57w2Hv6nh6rnxvg
+              text:
+                type: string
+                description: message text
+                example: Hello! How can I help you?
+              agentId:
+                type: string
+                description: agent ID. It can be found on agent’s page or received <a href="https://developers.brevo.com/docs/conversations-webhooks">from a webhook</a>. Alternatively, you can use `agentEmail` + `agentName` + `receivedFrom` instead (all 3 fields required).
+                example: d9nKoegKSjmCtyK78
+              receivedFrom:
+                type: string
+                description: mark your messages to distinguish messages created by you from the others.
+                example: SuperAwesomeHelpdesk
+              agentEmail:
+                type: string
+                format: email
+                description: agent email. When sending messages from a standalone system, it’s hard to maintain a 1-to-1 relationship between the users of both systems. In this case, an agent can be specified by their email address.
+                example: liz@getwear.com
+              agentName:
+                type: string
+                description: agent name
+                example: Liz
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Newly created message is returned as a response
+          schema:
+            $ref: '#/definitions/ConversationsMessage'
+          examples:
+            application/json:
+              {
+                "id": "eYBEm3gq3zc5ayE2g",
+                "type": "agent",
+                "text": "Hello! How can I help you?",
+                "html": "Hello! How can I help you?",
+                "visitorId": "kZMvWhf8npAu3H6qd57w2Hv6nh6rnxvg",
+                "agentId": "d9nKoegKSjmCtyK78",
+                "isTrigger": false,
+                "isPushed": false,
+                "isMissed": false,
+                "isMissedByVisitor": false,
+                "createdAt": 1482512803740,
+                "receivedFrom": "SuperAwesomeHelpdesk"
+              }
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+  /conversations/messages/{id}:
+    get:
+      tags:
+        - Conversations
+      summary: Get a message
+      parameters:
+        - in: path
+          name: id
+          type: string
+          required: true
+          description: ID of the message
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Requested message is returned as a response
+          schema:
+            $ref: '#/definitions/ConversationsMessage'
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+        - Conversations
+      summary: Update a message sent by an agent
+      description: Only agents’ messages can be edited.
+      parameters:
+        - in: path
+          name: id
+          type: string
+          required: true
+          description: ID of the message
+        - in: body
+          name: body
+          schema:
+            required:
+              - text
+            properties:
+              text:
+                type: string
+                description: edited message text
+            example:
+              edition:
+                value:
+                  text: Good morning! How can I help you?
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Updated message is returned as a response
+          schema:
+            $ref: '#/definitions/ConversationsMessage'
+          examples:
+            application/json: {
+              "id": "eYBEm3gq3zc5ayE2g",
+              "type": "agent",
+              "text": "Hello! How can I help you?",
+              "html": "Hello! How can I help you?",
+              "visitorId": "kZMvWhf8npAu3H6qd57w2Hv6nh6rnxvg",
+              "agentId": "d9nKoegKSjmCtyK78",
+              "isTrigger": false,
+              "isPushed": false,
+              "isMissed": false,
+              "isMissedByVisitor": false,
+              "createdAt": 1482512803740,
+              "receivedFrom": "SuperAwesomeHelpdesk"
+            }
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+        - Conversations
+      summary: Delete a message sent by an agent
+      description: Only agents’ messages can be deleted.
+      parameters:
+        - in: path
+          name: id
+          type: string
+          required: true
+          description: ID of the message
+      responses:
+        204:
+          description: The message was deleted from the conversation
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /conversations/pushedMessages:
+    post:
+      tags:
+        - Conversations
+      summary: Send an automated message to a visitor
+      description: "Example of automated messages: order status, announce new features in your web app, etc."
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            required:
+              - visitorId
+              - text
+            properties:
+              visitorId:
+                type: string
+                description: visitor’s ID received <a href="https://developers.brevo.com/docs/conversations-webhooks">from a webhook</a> or generated by you to <a href="https://developers.brevo.com/docs/customize-the-widget#identifying-existing-users">bind existing user account to Conversations</a>
+                example: kZMvWhf8npAu3H6qd57w2Hv6nh6rnxvg
+              text:
+                type: string
+                description: message text
+                example: "Your order has shipped! Here’s your tracking number: 9114 5847 3325 9667 4328 88"
+              agentId:
+                type: string
+                description: agent ID. It can be found on agent’s page or received <a href="https://developers.brevo.com/docs/conversations-webhooks">from a webhook</a>. Optional if `groupId` is set.
+                example: PjRBMhWGen6aRHjif
+              groupId:
+                type: string
+                description: group ID. It can be found on group’s page. Optional if `agentId` is set.
+                example: PjRBMhWGen6aRHjif
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Newly created message is returned as a response
+          schema:
+            $ref: '#/definitions/ConversationsMessage'
+          examples:
+            application/json: {
+              "id": "AXCR3k9bpSY7bpuh7",
+              "type": "agent",
+              "text": "Your order has shipped! Here’s your tracking number: 9114 5847 3325 9667 4328 88",
+              "html": "Your order has shipped! Here’s your tracking number: 9114 5847 3325 9667 4328 88",
+              "visitorId": "kZMvWhf8npAu3H6qd57w2Hv6nh6rnxvg",
+              "agentId": "d9nKoegKSjmCtyK78",
+              "isTrigger": false,
+              "isPushed": true,
+              "isMissed": false,
+              "isMissedByVisitor": false,
+              "createdAt": 1470222622433
+            }
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+  /conversations/pushedMessages/{id}:
+    get:
+      tags:
+        - Conversations
+      summary: Get an automated message
+      parameters:
+        - in: path
+          name: id
+          type: string
+          required: true
+          description: ID of the message sent previously
+      produces:
+        - application/json
+      responses:
+        200:
+          description: Requested message is returned as a response
+          schema:
+            $ref: '#/definitions/ConversationsMessage'
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+        - Conversations
+      summary: Update an automated message
+      parameters:
+        - in: path
+          name: id
+          type: string
+          required: true
+          description: ID of the message
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            required:
+              - text
+            properties:
+              text:
+                type: string
+                description: edited message text
+                example: "Your order has shipped! Here’s your tracking number: 9114 5847 4668 7775 9233 54"
+      responses:
+        200:
+          description: Updated message is returned as a response
+          schema:
+            $ref: '#/definitions/ConversationsMessage'
+          examples:
+            application/json: {
+              "id": "AXCR3k9bpSY7bpuh7",
+              "type": "agent",
+              "text": "Your order has shipped! Here’s your tracking number: 9114 5847 4668 7775 9233 54",
+              "visitorId": "kZMvWhf8npAu3H6qd57w2Hv6nh6rnxvg",
+              "agentId": "d9nKoegKSjmCtyK78",
+              "isTrigger": false,
+              "isPushed": true,
+              "isMissed": false,
+              "isMissedByVisitor": false,
+              "createdAt": 1470222622433
+            }
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+        - Conversations
+      summary: Delete an automated message
+      parameters:
+        - in: path
+          name: id
+          type: string
+          required: true
+          description: ID of the message
+      responses:
+        204:
+          description: The message was deleted from the conversation
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Returned when item not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /conversations/agentOnlinePing:
+    post:
+      tags:
+        - Conversations
+      summary: Sets agent’s status to online for 2-3 minutes
+      description: We recommend pinging this endpoint every minute for as long as the agent has to be considered online.
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: Agent fields.
+          schema:
+            type: object
+            properties:
+              agentId:
+                type: string
+                description: agent ID. It can be found on agent’s page or received <a href="https://developers.brevo.com/docs/conversations-webhooks">from a webhook</a>. Alternatively, you can use `agentEmail` + `agentName` + `receivedFrom` instead (all 3 fields required).
+                example: d9nKoegKSjmCtyK78
+              receivedFrom:
+                type: string
+                description: mark your messages to distinguish messages created by you from the others.
+                example: SuperAwesomeHelpdesk
+              agentEmail:
+                type: string
+                format: email
+                description: agent email. When sending online pings from a standalone system, it’s hard to maintain a 1-to-1 relationship between the users of both systems. In this case, an agent can be specified by their email address. If there’s no agent with the specified email address in your Brevo organization, a dummy agent will be created automatically.
+                example: liz@getwear.com
+              agentName:
+                type: string
+                description: agent name.
+                example: Liz
+      consumes:
+        - application/json
+      responses:
+        201:
+          description: Status of the agent was set successfully. Response body will be empty.
+        400:
+          description: Returned when invalid data posted
+          schema:
+            $ref: '#/definitions/errorModel'
+  /ecommerce/activate:
+    post:
+      tags:
+        - Ecommerce
+      summary: "Activate the eCommerce app"
+      description: "Getting access to Brevo eCommerce."
+      responses:
+        200:
+          description: 'eCommerce activation is in process, please wait for 5 minutes.'
+        401:
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: api-key not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /ecommerce/config/displayCurrency:
+    post:
+      tags:
+        - Ecommerce
+      summary: Set the ISO 4217 compliant display currency code for your Brevo account
+      operationId: setConfigDisplayCurrency
+      parameters:
+      - name: setConfigDisplayCurrency
+        description: set ISO 4217 compliant display currency code payload
+        in: body
+        required: true
+        schema:
+          type: object
+          required:
+            - code
+          properties:
+            code:
+              description: ISO 4217 compliant display currency code
+              type: string
+              example: "EUR"
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            required:
+              - code
+            properties:
+              code:
+                description: ISO 4217 compliant display currency code
+                type: string
+                example: "EUR"
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        401:
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/errorModel'
+        403:
+          description: Permission denied. eCommerce is not activated.
+          schema:
+            $ref: '#/definitions/errorModel'
+        422:
+          description: Invalid ISO 4217 currency code.
+          schema:
+            $ref: '#/definitions/errorModel'
+    get:
+      tags:
+        - Ecommerce
+      summary: Get the ISO 4217 compliant display currency code for your Brevo account
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            required:
+              - code
+            properties:
+              code:
+                description: ISO 4217 compliant display currency code
+                type: string
+                example: "EUR"
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        401:
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/errorModel'
+        403:
+          description: Permission denied. eCommerce is not activated.
+          schema:
+            $ref: '#/definitions/errorModel'
+  /ecommerce/attribution/metrics:
+    get:
+      tags:
+        - Ecommerce
+      summary: Get attribution metrics for one or more Brevo campaigns or workflows
+      parameters:
+        - in: query
+          name: periodFrom
+          description: When getting metrics for a specific period, define the starting datetime in RFC3339 format
+          type: string
+          format: date-time
+        - in: query
+          name: periodTo
+          description: When getting metrics for a specific period, define the end datetime in RFC3339 format
+          type: string
+          format: date-time
+        - in: query
+          name: emailCampaignId[]
+          description: The email campaign ID(s) to get metrics for
+          type: array
+          items:
+            type: string
+        - in: query
+          name: smsCampaignId[]
+          description: The SMS campaign ID(s) to get metrics for
+          type: array
+          items:
+            type: string
+        - in: query
+          name: automationWorkflowEmailId[]
+          description: The automation workflow ID(s) to get email attribution metrics for
+          type: array
+          items:
+            type: string
+        - in: query
+          name: automationWorkflowSmsId[]
+          description: The automation workflow ID(s) to get SMS attribution metrics for
+          type: array
+          items:
+            type: string
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            required:
+              - results
+              - totals
+            properties:
+              results:
+                description: List of conversion attribution metrics
+                type: array
+                example: [
+                  {"id": "sale1", "conversionSource": "email_campaign", "ordersCount":300, "revenue":900, "averageBasket":3.00},
+                  {"id": "sale2", "conversionSource": "email_campaign", "ordersCount":200, "revenue":800, "averageBasket":4.00}
+                ]
+                items:
+                  type: object
+                  $ref: "#/definitions/ConversionSourceMetrics"
+              totals:
+                description: Attribution list aggregated totals
+                type: object
+                example: {
+                  "ordersCount": 500,
+                  "revenue": 1700.00,
+                  "averageBasket": 3.40
+                }
+                required:
+                  - ordersCount
+                  - revenue
+                  - averageBasket
+                properties:
+                  ordersCount:
+                    type: number
+                    format: integer
+                  revenue:
+                    type: number
+                    format: float
+                  averageBasket:
+                    type: number
+                    format: float
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+
+  /ecommerce/attribution/metrics/{conversionSource}/{conversionSourceId}:
+    get:
+      tags:
+        - Ecommerce
+      summary: Get detailed attribution metrics for a single Brevo campaign or workflow
+      parameters:
+        - in: path
+          name: conversionSource
+          description: The Brevo campaign type or workflow type for which data will be retrieved
+          required: true
+          type: string
+          enum:
+            - email_campaign
+            - sms_campaign
+            - automation_workflow_email
+            - automation_workflow_sms
+        - in: path
+          name: conversionSourceId
+          description: The Brevo campaign or automation workflow id for which data will be retrieved
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK
+          schema:
+            allOf:
+            - $ref: "#/definitions/ConversionSourceMetrics"
+            - type: object
+              required:
+              - newCustomersCount
+              properties:
+                newCustomersCount:
+                  type: number
+                  format: integer
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+
+  /ecommerce/attribution/products/{conversionSource}/{conversionSourceId}:
+    get:
+      tags:
+        - Ecommerce
+      summary: Get attributed product sales for a single Brevo campaign or workflow
+      parameters:
+        - in: path
+          name: conversionSource
+          description: The Brevo campaign or automation workflow type for which data will be retrieved
+          required: true
+          type: string
+          enum:
+            - email_campaign
+            - sms_campaign
+            - automation_workflow_email
+            - automation_workflow_sms
+        - in: path
+          name: conversionSourceId
+          description: The Brevo campaign or automation workflow id for which data will be retrieved
+          required: true
+          type: string
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            required:
+              - products
+            properties:
+              products:
+                description: List of attributed products
+                type: array
+                items:
+                  type: object
+                  $ref: "#/definitions/ConversionSourceProduct"
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /orders:
+    get:
+      tags:
+        - Ecommerce
+      summary: Get order details
+      description: Get all the orders
+      operationId: getOrders
+      parameters:
+      - name: limit
+        in: query
+        description: Number of documents per page
+        maximum: 100
+        type: integer
+        format: int64
+        default: 50
+      - name: offset
+        in: query
+        description: Index of the first document in the page
+        type: integer
+        format: int64
+        default: 0
+      - name: sort
+        in: query
+        description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+        required: false
+        type: string
+        default: desc
+        enum:
+          - asc
+          - desc
+      - name: modifiedSince
+        in: query
+        description: |
+          Filter (urlencoded) the orders modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). **Prefer to pass your timezone in date-time format for accurate result.**
+        type: string
+      - name: createdSince
+        in: query
+        description: |
+          Filter (urlencoded) the orders created after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). **Prefer to pass your timezone in date-time format for accurate result.**
+        type: string
+      responses:
+        200:
+          description: orders fetched successfully
+          schema:
+            $ref: '#/definitions/getOrders'
+          examples:
+            response:
+              value:
+                  orders:
+                  - id: order1803
+                    createdAt: 2021-12-31T11:42:35.638Z
+                    updatedAt: 2022-03-03T14:48:31.867Z
+                    contact_id: 2
+                    status: complete
+                    amount: 2000
+                    storeId: "123"
+                    identifiers:
+                      loyalty_subscription_id: "1234"
+                      ext_id: "ab12"
+                    billing:
+                      address: Sec 62, Noida
+                      city: Noida
+                      countryCode: IN
+                      country: India
+                      phone: 9238283982
+                      postCode: 110001
+                      paymentMethod: Net banking
+                      region: North India
+                    products:
+                      - productId: 21
+                        quantity: 2
+                        variantId: P100
+                        price: 100
+                      - productId: 21
+                        quantity: 2
+                        variantId: P15756
+                        price: 100
+                    email: testvisitor@sendinblue.com
+                    coupons: [
+                      "flat50",
+                      "flat40"
+                    ]
+                  count: 1
+
+        400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+
+
+  /orders/status:
+    post:
+      tags:
+        - Ecommerce
+      summary: Managing the status of the order
+      description: Manages the transactional status of the order
+      operationId: createOrder
+      parameters:
+      - name: order
+        required: true
+        in: body
+        schema:
+          $ref: '#/definitions/order'
+      responses:
+        204:
+          description: Order Event posted
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /orders/status/batch:
+      post:
+        tags:
+        - Ecommerce
+        summary: Create orders in batch
+        description: Create multiple orders at one time instead of one order at a time
+        operationId: createBatchOrder
+        parameters:
+        - name: orderBatch
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/orderBatch'
+        responses:
+          202:
+            $ref: '#/definitions/createdBatchId'
+          400:
+            description: bad request
+            schema:
+              $ref: '#/definitions/errorModel'
+  /events:
+    post:
+      tags:
+        - Events
+      summary: Create an event
+      description: Create an event to track a contact's interaction.
+      operationId: createEvent
+      parameters:
+      - name: event
+        required: true
+        in: body
+        schema:
+          $ref: '#/definitions/event'
+      responses:
+        204:
+          description: An event posted
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        401:
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/errorModel'
+  /categories:
+    get:
+      tags:
+      - Ecommerce
+      summary: Return all your categories
+      operationId: getCategories
+      parameters:
+      - name: limit
+        in: query
+        description: Number of documents per page
+        type: integer
+        maximum: 100
+        format: int64
+        default: 50
+      - name: offset
+        in: query
+        description: Index of the first document in the page
+        type: integer
+        format: int64
+        default: 0
+      - name: sort
+        in: query
+        description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+        required: false
+        type: string
+        default: desc
+        enum:
+          - asc
+          - desc
+      - name: ids
+        in: query
+        type: array
+        items:
+          type: string
+        description: Filter by category ids
+      - name: name
+        in: query
+        type: string
+        description: Filter by category name
+      - name: modifiedSince
+        in: query
+        description: |
+          Filter (urlencoded) the categories modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). **Prefer to pass your timezone in date-time format for accurate result.**
+        type: string
+      - name: createdSince
+        in: query
+        description: |
+          Filter (urlencoded) the categories created after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). **Prefer to pass your timezone in date-time format for accurate result.**
+        type: string
+      - name: isDeleted
+        in: query
+        description: |
+          Filter categories by their deletion status. If `false` is passed, only categories that are not deleted will be returned.
+        schema:
+          type: boolean
+
+      responses:
+        200:
+          description: All categories listed
+          schema:
+            $ref: '#/definitions/getCategories'
+          examples:
+            application/json: {
+                "categories": [
+                  {
+                    "id": 19,
+                    "name": "Food",
+                    "url": "https://mydomain.com/category/food",
+                    "modifiedAt": "2022-03-03T14:48:31.867Z",
+                    "createdAt": "2021-12-31T11:42:35.638Z"
+                  },
+                  {
+                    "id": 20,
+                    "name": "clothing",
+                    "url": "https://mydomain.com/category/food",
+                    "modifiedAt": "2022-03-03T14:48:31.867Z",
+                    "createdAt": "2021-12-31T11:42:35.638Z",
+                    "isDeleted": true
+                  }
+                ],
+                "count": 2
+            }
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+      - Ecommerce
+      summary: Create/Update a category
+      operationId: createUpdateCategory
+      parameters:
+      - name: createUpdateCategory
+        description: Values to create/update a category
+        in: body
+        schema:
+          $ref: '#/definitions/createUpdateCategory'
+        required: true
+      responses:
+        201:
+          description: Category created
+          schema:
+            $ref: '#/definitions/createCategoryModel'
+        204:
+          description: Category updated
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /categories/{id}:
+    get:
+      tags:
+      - Ecommerce
+      summary: Get a category details
+      operationId: getCategoryInfo
+      parameters:
+      - name: id
+        in: path
+        description: Category ID
+        required: true
+        type: string
+      responses:
+        200:
+          description: Category informations
+          schema:
+            $ref: '#/definitions/getCategoryDetails'
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Category id not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /categories/batch:
+    post:
+      tags:
+      - Ecommerce
+      summary: Create categories in batch
+      operationId: createUpdateBatchCategory
+      parameters:
+      - name: createUpdateBatchCategory
+        description: Values to create a batch of categories
+        schema:
+          $ref: '#/definitions/createUpdateBatchCategory'
+        required: true
+        in: body
+      responses:
+        201:
+          description: Category created and updated
+          schema:
+            $ref: '#/definitions/createUpdateBatchCategoryModel'
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /products:
+    get:
+      tags:
+      - Ecommerce
+      summary: Return all your products
+      operationId: getProducts
+      parameters:
+      - name: limit
+        in: query
+        description: Number of documents per page
+        maximum: 1000
+        type: integer
+        format: int64
+        default: 50
+      - name: offset
+        in: query
+        description: Index of the first document in the page
+        type: integer
+        format: int64
+        default: 0
+      - name: sort
+        in: query
+        description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+        required: false
+        type: string
+        default: desc
+        enum:
+          - asc
+          - desc
+      - name: ids
+        in: query
+        type: array
+        items:
+          type: string
+        description: Filter by product ids
+      - name: name
+        in: query
+        description: Filter by product name, minimum 3 characters should be present for search
+        required: false
+        type: string
+      - name: price[lte]
+        in: query
+        type: number
+        description: Price filter for products less than and equals to particular amount
+      - name: price[gte]
+        in: query
+        type: number
+        description: Price filter for products greater than and equals to particular amount
+      - name: price[lt]
+        in: query
+        type: number
+        description: Price filter for products less than particular amount
+      - name: price[gt]
+        in: query
+        type: number
+        description: Price filter for products greater than particular amount
+      - name: price[eq]
+        in: query
+        type: number
+        description: Price filter for products equals to particular amount
+      - name: price[ne]
+        in: query
+        type: number
+        description: Price filter for products not equals to particular amount
+      - name: categories
+        in: query
+        type: array
+        items:
+          type: string
+        description: Filter by category ids
+      - name: modifiedSince
+        in: query
+        description: |
+          Filter (urlencoded) the orders modified after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). **Prefer to pass your timezone in date-time format for accurate result.**
+        type: string
+      - name: createdSince
+        in: query
+        description: |
+          Filter (urlencoded) the orders created after a given UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). **Prefer to pass your timezone in date-time format for accurate result.**
+        type: string
+      - name: isDeleted
+        in: query
+        description: |
+          Filter products by their deletion status. If `false` is passed, only products that are not deleted will be returned.
+        schema:
+          type: boolean
+      responses:
+        200:
+          description: All products listed
+          schema:
+            $ref: '#/definitions/getProducts'
+          examples:
+              application/json: {
+                    "products": [
+                      {
+                        "id": 7498033266862,
+                        "name": "Alpina Panoma Classic",
+                        "url": "https://mydomain.com/products/alpina-panoma-classic",
+                        "sku": "186622-9",
+                        "imageUrl": "http://mydomain.com/product-absoulte-url/img.jpeg",
+                        "categories": [
+                          "279638835374",
+                          "279502848174"
+                        ],
+                        "price": 49.95,
+                        "modifiedAt": "2022-06-30T10:29:16.078Z",
+                        "createdAt": "2022-06-30T10:29:16.078Z",
+                        "s3Original": "https://img-ecom.mailinblue.com/path-to-original/img.jpg",
+                        "s3ThumbAnalytics": "https://img-ecom.mailinblue.com/path-to-analytics/img.jpg",
+                        "s3ThumbEditor": "https://img-ecom.mailinblue.com/path-to-editor/img.jpg",
+                        "stock": 100
+                      },
+                      {
+                        "id": 7498033266862,
+                        "name": "Alpina Panoma Classic2",
+                        "url": "https://mydomain.com/products/alpina-panoma-classic2",
+                        "sku": "186622-9",
+                        "imageUrl": "http://mydomain.com/product-absoulte-url/img.jpeg",
+                        "categories": [
+                          "2d79638835374",
+                          "27d9502848174"
+                        ],
+                        "price": 49.95,
+                        metaInfo: {
+                          description: "Shoes for sports",
+                          brand: "addidas",
+                        },
+                        "modifiedAt": "2022-06-30T10:29:16.078Z",
+                        "createdAt": "2022-06-30T10:29:16.078Z",
+                        "s3Original": "https://img-ecom.mailinblue.com/path-to-original/img.jpg",
+                        "s3ThumbAnalytics": "https://img-ecom.mailinblue.com/path-to-analytics/img.jpg",
+                        "s3ThumbEditor": "https://img-ecom.mailinblue.com/path-to-editor/img.jpg",
+                        "isDeleted": true,
+                        "stock": 350
+                      }
+                    ],
+                    "count": 2
+                }
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+      - Ecommerce
+      summary: Create/Update a product
+      operationId: createUpdateProduct
+      parameters:
+        - name : createUpdateProduct
+          description: Values to create/update a product
+          schema:
+            $ref: '#/definitions/createUpdateProduct'
+          required: true
+          in: body
+      responses:
+        201:
+          description: Product created
+          schema:
+            $ref: '#/definitions/createProductModel'
+          examples:
+              application/json: {
+                  "id": 21
+              }
+        204:
+          description: Product updated
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /products/{id}:
+    get:
+      tags:
+      - Ecommerce
+      summary: Get a product's details
+      operationId: getProductInfo
+      parameters:
+      - name: id
+        in: path
+        description: Product ID
+        required: true
+        type: string
+      responses:
+        200:
+          description: Product informations
+          schema:
+            $ref: '#/definitions/getProductDetails'
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Product's id not found
+          schema:
+            $ref: '#/definitions/errorModel'
+  /products/batch:
+    post:
+      tags:
+      - Ecommerce
+      summary: Create products in batch
+      operationId: createUpdateBatchProducts
+      parameters:
+      - name: createUpdateBatchProducts
+        description: Values to create a batch of products
+        schema:
+          $ref: '#/definitions/createUpdateBatchProducts'
+        required: true
+        in: body
+      responses:
+        201:
+          description: Products created and updated
+          schema:
+            $ref: '#/definitions/createUpdateBatchProductsModel'
+          examples:
+              application/json: {
+                  "createdCount": 2,
+                  "updatedCount": 7
+              }
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /products/{id}/alerts/{type}:
+    post:
+       tags:
+        - Ecommerce
+       summary: Create a product alert for a contact
+       operationId: createProductAlert
+       parameters:
+       - name: id
+         in: path
+         description: Product ID
+         required: true
+         type: string
+       - name: type
+         in: path
+         description: Alert type
+         required: true
+         type: string
+         enum:
+            - back_in_stock
+       - name: contactIdentifiers
+         in: body
+         description: Contact identifier to associate the alert with (at least one is required). Priority is given to `ext_id` > `email` > `sms`
+         required: true
+         schema:
+          type: object
+          properties:
+            contactIdentifiers:
+              type: object
+              properties:
+                email:
+                  type: string
+                  description: Email address of the contact
+                  format: email
+                  example: elly@example.com
+                sms:
+                  type: string
+                  description: Sms of the contact
+                  example: +91xxxxxxxxxx
+                ext_id:
+                  type: string
+                  description: Contact ID in your system
+                  example: ExternalId
+       responses:
+          204:
+            description: Product alert was created
+          400:
+            description: Product alert could not be created
+            schema:
+              $ref: '#/definitions/errorModelWithStatus'
+          401:
+            description: unauthorized
+            schema:
+              $ref: '#/definitions/errorModelWithStatus'
+          403:
+            description: Product alerts is not allowed for this account
+            schema:
+              $ref: '#/definitions/errorModelWithStatus'
+          404:
+            description: Product ID not found
+            schema:
+              $ref: '#/definitions/errorModelWithStatus'
+  /couponCollections:
+    get:
+      tags:
+      - Coupons
+      summary: Get all your coupon collections
+      operationId: getCouponCollections
+      parameters:
+      - name: limit
+        in: query
+        description: Number of documents returned per page
+        type: integer
+        format: int64
+        default: 50
+        minimum: 0
+        maximum: 100
+      - name: offset
+        in: query
+        description: Index of the first document on the page
+        type: integer
+        format: int64
+        default: 0
+        minimum: 0
+      - name: sort
+        in: query
+        description: Sort the results by creation time in ascending/descending order
+        type: string
+        enum:
+        - asc
+        - desc
+        default: desc
+      - name: sortBy
+        in: query
+        description: The field used to sort coupon collections
+        required: false
+        type: string
+        enum:
+          - createdAt
+          - remainingCoupons
+          - expirationDate
+        default: createdAt
+      responses:
+        200:
+          description: Coupon collections
+          schema:
+            $ref: '#/definitions/getCouponCollection'
+          examples:
+            response:
+              value:
+                collections:
+                  - id: 23befbae-1505-47a8-bd27-e30ef739f32c
+                    name: Summer
+                    defaultCoupon: 10 OFF
+                    createdAt: 2017-03-12T12:30:00Z
+                    totalCoupons: 10000
+                    remainingCoupons: 5000
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        401:
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Record not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+        - Coupons
+      summary: Create а coupon collection
+      operationId: createCouponCollection
+      parameters:
+      - name: createCouponCollection
+        description: Values to create a coupon collection
+        in: body
+        required: true
+        schema:
+          type: object
+          required:
+            - name
+            - defaultCoupon
+          properties:
+            name:
+              description: Name of the coupons collection
+              type: string
+              example: "10%OFF"
+            defaultCoupon:
+              description: Default coupons collection name
+              type: string
+              example: "Winter"
+            expirationDate:
+              description: Specify an expiration date for the coupon collection in RFC3339 format. Use null to remove the expiration date.
+              type: string
+              format: date-time
+              example: "2022-01-02T00:00:00Z"
+            remainingDaysAlert:
+              description: Send a notification alert (email) when the remaining days until the expiration date are equal or fall bellow this number. Use null to disable alerts.
+              type: integer
+              example: 5
+            remainingCouponsAlert:
+              description: Send a notification alert (email) when the remaining coupons count is equal or fall bellow this number. Use null to disable alerts.
+              type: integer
+              example: 5
+      responses:
+        201:
+          description: Coupon collection created
+          schema:
+            required:
+            - id
+            type: object
+            properties:
+              id:
+                type: string
+                description: The id of the created collection
+                format: uuidv4
+                example: 23befbae-1505-47a8-bd27-e30ef739f32c
+        401:
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/errorModel'
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /couponCollections/{id}:
+    get:
+      tags:
+      - Coupons
+      summary: Get a coupon collection by id
+      operationId: getCouponCollection
+      parameters:
+      - name: id
+        in: path
+        description: Id of the collection to return
+        required: true
+        type: string
+        format: uuidv4
+      responses:
+        200:
+          description: Coupon collection
+          schema:
+            $ref: '#/definitions/getCouponCollection'
+          examples:
+            response:
+              value:
+                - id: 23befbae-1505-47a8-bd27-e30ef739f32c
+                  name: Summer
+                  defaultCoupon: 10 OFF
+                  createdAt: 2017-03-12T12:30:00Z
+                  totalCoupons: 10000
+                  remainingCoupons: 5000
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        401:
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Coupon collection not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    patch:
+      tags:
+      - Coupons
+      summary: Update a coupon collection by id
+      operationId: updateCouponCollection
+      parameters:
+      - name: id
+        description: Id of the collection to update
+        in: path
+        required: true
+        type: string
+        format: uuidv4
+      - name: updateCouponCollection
+        description: Values to update the coupon collection
+        in: body
+        schema:
+          type: object
+          properties:
+            defaultCoupon:
+              type: string
+              description: A default coupon to be used in case there are no coupons left
+              example: 10 OFF
+            expirationDate:
+              description: Specify an expiration date for the coupon collection in RFC3339 format. Use null to remove the expiration date.
+              type: string
+              format: date-time
+              example: "2024-01-01T00:00:00Z"
+            remainingDaysAlert:
+              description: Send a notification alert (email) when the remaining days until the expiration date are equal or fall bellow this number. Use null to disable alerts.
+              type: integer
+              example: 5
+            remainingCouponsAlert:
+              description: Send a notification alert (email) when the remaining coupons count is equal or fall bellow this number. Use null to disable alerts.
+              type: integer
+              example: 5
+      responses:
+        200:
+          description: Coupon collection updated
+          schema:
+            required:
+            - id
+            - name
+            type: object
+            properties:
+              id:
+                type: string
+                description: The id of the collection
+                format: uuidv4
+                example: 23befbae-1505-47a8-bd27-e30ef739f32c
+              name:
+                type: string
+                description: The name of the collection
+                format: uuidv4
+                example: SummerPromotions
+              defaultCoupon:
+                type: string
+                description: The default coupon of the collection
+                example: 10 OFF
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        401:
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/errorModel'
+  /coupons:
+    post:
+      tags:
+      - Coupons
+      summary: Create coupons for a coupon collection
+      operationId: createCoupons
+      parameters:
+      - name: createCoupons
+        in: body
+        description: Values to create coupons
+        required: true
+        schema:
+          required:
+          - collectionId
+          - coupons
+          type: object
+          properties:
+            collectionId:
+              type: string
+              description: The id of the coupon collection for which the coupons will be created
+              format: uuidv4
+              example: 23befbae-1505-47a8-bd27-e30ef739f32c
+            coupons:
+              type: array
+              minItems: 1
+              maxItems: 10000
+              uniqueItems: true
+              items:
+                type: string
+                description: Name of the coupon
+                example: Uf12AF
+      responses:
+        204:
+          description: Coupons creation in progress
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        401:
+          description: unauthorized
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Coupon collection not found
+          schema:
+            $ref: '#/definitions/errorModel'
+
+  /whatsapp/sendMessage:
+    post:
+      tags:
+        - Transactional WhatsApp
+      summary: Send a WhatsApp message
+      description: This endpoint is used to send a WhatsApp message. <br/>(**The first message you send using the API must contain a Template ID. You must create a template on WhatsApp on the Brevo platform to fetch the Template ID.**)
+      operationId: sendWhatsappMessage
+      parameters:
+        - name: sendWhatsappMessage
+          description: Values to send WhatsApp message
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/sendWhatsappMessage'
+      responses:
+        201:
+          description: successfully created
+          schema:
+            required:
+            - messageId
+            type: object
+            properties:
+              messageId:
+                type: string
+                description: messageId of sent message
+                format: uuidv4
+                example: "23befbae-1505-47a8-bd27-e30ef739f32c"
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /whatsapp/statistics/events:
+    get:
+      tags:
+      - Transactional WhatsApp
+      summary: Get all your WhatsApp activity (unaggregated events)
+      description: This endpoint will show the unaggregated statistics for WhatsApp activity (30 days by default if `startDate` and `endDate` or `days` is not passed. The date range can not exceed 90 days)
+      operationId: getWhatsappEventReport
+      parameters:
+      - name: limit
+        in: query
+        description: Number limitation for the result returned
+        maximum: 10000
+        type: integer
+        format: int64
+        default: 2500
+        minimum: 0
+      - name: offset
+        in: query
+        description: Beginning point in the list to retrieve from
+        type: integer
+        format: int64
+        default: 0
+      - name: startDate
+        in: query
+        description: |
+          **Mandatory if endDate is used.** Starting date of the report (YYYY-MM-DD). Must be lower than equal to endDate
+        type: string
+      - name: endDate
+        in: query
+        description: |
+          **Mandatory if startDate is used.** Ending date of the report (YYYY-MM-DD). Must be greater than equal to startDate
+        type: string
+      - name: days
+        in: query
+        description: |
+          Number of days in the past including today (positive integer). _Not compatible with 'startDate' and 'endDate'_
+        type: integer
+        format: int64
+      - name: contactNumber
+        in: query
+        description: Filter results for specific contact (WhatsApp Number with country code. Example, 85264318721)
+        type: string
+        format: mobile
+      - name: event
+        in: query
+        description: Filter the report for a specific event type
+        type: string
+        enum:
+        - sent
+        - delivered
+        - read
+        - error
+        - unsubscribe
+        - reply
+        - soft-bounce
+      - name: sort
+        in: query
+        description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed
+        required: false
+        type: string
+        default: desc
+        enum:
+          - asc
+          - desc
+      responses:
+        200:
+          description: WhatsApp events report
+          schema:
+            $ref: '#/definitions/getWhatsappEventReport'
+          examples:
+            application/json:
+              response:
+                value:
+                  events:
+                    - contactNumber: 919876543211
+                      date: 2017-03-12T12:30:00Z
+                      messageId: 23befbae-1505-47a8-bd27-e30ef739f32c
+                      event: sent
+                      senderNumber: 919876543210
+                    - contactNumber: 919876543211
+                      date: 2017-03-12T12:30:00Z
+                      messageId: 23befbae-1505-47a8-bd27-e30ef739f32c
+                      event: "error"
+                      reason: "error reason"
+                      senderNumber: 919876543210
+                    - contactNumber: 919876543211
+                      date: 2017-03-12T12:30:00Z
+                      messageId: 23befbae-1505-47a8-bd27-e30ef739f32c
+                      event: "soft-bounce"
+                      reason: "invalid whatsapp contact"
+                      senderNumber: 919876543210
+                    - contactNumber: 919876543211
+                      date: 2017-03-12T12:30:00Z
+                      messageId: 23befbae-1505-47a8-bd27-e30ef739f32c
+                      event: "reply"
+                      body: "body only in case of text reply & url will be empty"
+                      mediaUrl: "media url only in case media reply & body will be empty"
+                      senderNumber: 919876543210
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+
+  /feeds:
+    get:
+      tags:
+      - External Feeds
+      summary: Fetch all external feeds
+      description: This endpoint can fetch all created external feeds.
+      operationId: getAllExternalFeeds
+      parameters:
+        - name: search
+          description: Can be used to filter records by search keyword on feed name
+          in: query
+          required: false
+          type: string
+        - name: startDate
+          description: Mandatory if `endDate` is used. Starting date (YYYY-MM-DD) from which you want to fetch the list. Can be maximum 30 days older than current date.
+          in: query
+          required: false
+          type: string
+          format: date
+        - name: endDate
+          description: Mandatory if `startDate` is used. Ending date (YYYY-MM-DD) till which you want to fetch the list. Maximum time period that can be selected is one month.
+          in: query
+          required: false
+          type: string
+          format: date
+        - name: sort
+          in: query
+          description: Sort the results in the ascending/descending order of record creation. Default order is **descending** if `sort` is not passed.
+          required: false
+          type: string
+          default: desc
+          enum:
+            - asc
+            - desc
+        - name: authType
+          in: query
+          description: Filter the records by `authType` of the feed.
+          required: false
+          type: string
+          enum:
+            - basic
+            - token
+            - noAuth
+        - name: limit
+          description: Number of documents returned per page.
+          in: query
+          required: false
+          type: integer
+          format: int64
+          default: 50
+          maximum: 500
+          minimum: 0
+        - name: offset
+          description: Index of the first document on the page.
+          in: query
+          required: false
+          type: integer
+          format : int64
+          default: 0
+      responses:
+        200:
+          description: External feeds
+          schema:
+            $ref: '#/definitions/getAllExternalFeeds'
+          examples:
+            application/json:
+              {
+                "count": 3,
+                "feeds": [
+                  {
+                      "id": "d955aaa4-f4d6-4557-aa14-24286542ed8d",
+                      "name": "api feed token",
+                      "url": "https://abc.com/",
+                      "authType": "token",
+                      "token": "jfhdkjdfhjkfdhjkdfhjkdfhkj",
+                      "headers": [
+                          {
+                              "name": "key",
+                              "value": "val"
+                          }
+                      ],
+                      "maxRetries": 4,
+                      "cache": true,
+                      "createdAt": "2022-10-06T05:03:47.053000000Z",
+                      "modifiedAt": "2022-10-06T05:03:47.053000000Z"
+                  },
+                  {
+                      "id": "311a71ac-bebc-42cf-963d-d8666dfe53e9",
+                      "name": "api feed basic",
+                      "url": "https://abc.com/",
+                      "authType": "basic",
+                      "username": "user",
+                      "password": "pass",
+                      "headers": null,
+                      "maxRetries": 2,
+                      "cache": false,
+                      "createdAt": "2022-10-06T04:48:19.767000000Z",
+                      "modifiedAt": "2022-10-06T04:48:19.767000000Z"
+                  }
+                ]
+              }
+        400:
+          description: Invalid parameters passed
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Record not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      tags:
+        - External Feeds
+      summary: Create an external feed
+      description: This endpoint will create an external feed.
+      operationId: createExternalFeed
+      parameters:
+      - name: createExternalFeed
+        description: Values to create a feed
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/createExternalFeed'
+      responses:
+        201:
+          description: successfully created
+          schema:
+            required:
+            - id
+            type: object
+            properties:
+              id:
+                type: string
+                description: ID of the object created
+                format: uuidv4
+                example: "23befbae-1505-47a8-bd27-e30ef739f32c"
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+  /feeds/{uuid}:
+    get:
+      tags:
+        - External Feeds
+      summary: Get an external feed by UUID
+      description: This endpoint will update an external feed.
+      operationId: getExternalFeedByUUID
+      parameters:
+      - name: uuid
+        description: UUID of the feed to fetch
+        in: path
+        required: true
+        type: string
+      responses:
+        200:
+          description: External feed
+          schema:
+            $ref: '#/definitions/getExternalFeedByUUID'
+          examples:
+            application/json:
+                {
+                    "id": "d955aaa4-f4d6-4557-aa14-24286542ed8d",
+                    "name": "api feed token",
+                    "url": "https://abc.com/",
+                    "authType": "token",
+                    "token": "jfhdkjdfhjkfdhjkdfhjkdfhkj",
+                    "headers": [
+                        {
+                            "name": "key",
+                            "value": "val"
+                        }
+                    ],
+                    "maxRetries": 4,
+                    "cache": true,
+                    "createdAt": "2022-10-06T05:03:47.053000000Z",
+                    "modifiedAt": "2022-10-06T05:03:47.053000000Z"
+                }
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Feed not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    put:
+      tags:
+        - External Feeds
+      summary: Update an external feed
+      description: This endpoint will update an external feed.
+      operationId: updateExternalFeed
+      parameters:
+      - name: uuid
+        description: UUID of the feed to update
+        in: path
+        required: true
+        type: string
+      - name: updateExternalFeed
+        description: Values to update a feed
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/updateExternalFeed'
+      responses:
+        204:
+          description: Feed updated
+          examples:
+            application/json:
+              {}
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Feed not found
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      tags:
+        - External Feeds
+      summary: Delete an external feed
+      description: This endpoint will delete an external feed.
+      operationId: deleteExternalFeed
+      parameters:
+      - name: uuid
+        description: UUID of the feed to delete
+        in: path
+        required: true
+        type: string
+      responses:
+        204:
+          description: Feed deleted
+          examples:
+            application/json:
+              {}
+        400:
+          description: bad request
+          schema:
+            $ref: '#/definitions/errorModel'
+        404:
+          description: Feed not found
+          schema:
+            $ref: '#/definitions/errorModel'
+
+  /payments/requests:
+    post:
+      tags:
+        - Payments
+      summary: Create a payment request
+      operationId: createPaymentRequest
+      parameters:
+        - in: body
+          description: |
+            Create a payment request
+          name: create payment rquest
+          schema:
+              $ref: '#/definitions/createPaymentRequest'
+          required: true
+
+      responses:
+        '201':
+          description: Payment request created.
+          schema:
+            $ref: '#/definitions/createPaymentResponse'
+          examples:
+            response:
+              value:
+                id: 6d4ec0b2b48ef803df4103ve
+                url: https://pay.brevo.com/6d4ec0b2b48ef803df4103ve
+        '400':
+          description: Bad request.
+          schema:
+            $ref: '#/definitions/errorModel'
+        '401':
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/errorModel'
+        '403':
+          description: Permission denied. Either you don't have access to Brevo Payments or your Brevo Payments account is not validated.
+          schema:
+            $ref: '#/definitions/errorModel'
+
+  /payments/requests/{id}:
+    get:
+      tags:
+        - Payments
+      summary: Get payment request details
+      operationId: getPaymentRequest
+      parameters:
+        - name: id
+          in: path
+          description: Id of the payment Request
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Payment request details
+          schema:
+            $ref: '#/definitions/getPaymentRequest'
+        '400':
+          description: Bad request.
+          schema:
+                $ref: '#/definitions/errorModel'
+        '401':
+          description: Unauthorized.
+          schema:
+                $ref: '#/definitions/errorModel'
+        '403':
+          description: Permission denied. Either you don't have access to Brevo Payments or your Brevo Payments account is not validated.
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Payment request not found.
+          schema:
+            $ref: '#/definitions/errorModel'
+
+    delete:
+      tags:
+        - Payments
+      summary: Delete a payment request.
+      operationId: deletePaymentRequest
+      parameters:
+        - name: id
+          in: path
+          description: ID of the payment request.
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Payment request deleted successfully.
+        '401':
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/errorModel'
+        '403':
+          description: Permission denied. Either you don't have access to Brevo Payments or your Brevo Payments account is not validated.
+          schema:
+            $ref: '#/definitions/errorModel'
+        '404':
+          description: Payment request not found.
+          schema:
+            $ref: '#/definitions/errorModel'
+
+
+securityDefinitions:
+  api-key:
+    type: apiKey
+    name: api-key
+    description: The API key should be passed in the request headers as `api-key` for authentication.
+    in: header
+  partner-key:
+    type: apiKey
+    name: partner-key
+    description: The partner key should be passed in the request headers as `partner-key` along with `api-key` pair for successful authentication of partner (Optional).
+    in: header
+
+security:
+  - api-key: []
+  - partner-key: []
+
+definitions:
+
+  getAccount:
+    allOf:
+    - $ref: '#/definitions/getExtendedClient'
+    - type: object
+      required:
+        - plan
+        - relay
+      properties:
+        plan:
+          description: Information about your plans and credits
+          type: array
+          items:
+            type: object
+            required:
+              - type
+              - creditsType
+              - credits
+            properties:
+              type:
+                type: string
+                description : Displays the plan type of the user
+                enum:
+                  - payAsYouGo
+                  - free
+                  - subscription
+                  - sms
+                example : 'subscription'
+              creditsType:
+                type: string
+                description: This is the type of the credit, "Send Limit" is one of the possible types of credit of a user. "Send Limit" implies the total number of emails you can send to the subscribers in your account.
+                enum:
+                  - sendLimit
+                example : 'sendLimit'
+              credits:
+                type: number
+                format: float
+                description: Remaining credits of the user
+                example: 8755
+              startDate:
+                description: Date of the period from which the plan will start (only available for "subscription" plan type)
+                type: string
+                format: date
+                example: '2016-12-31'
+              endDate:
+                description: Date of the period from which the plan will end (only available for "subscription" plan type)
+                type: string
+                format: date
+                example: '2017-01-31'
+        relay:
+          description : Information about your transactional email account
+          type: object
+          required:
+            - enabled
+            - data
+          properties:
+            enabled :
+              description : Status of your transactional email Account (true=Enabled, false=Disabled)
+              type: boolean
+              example : true
+            data:
+              type: object
+              description: Data regarding the transactional email account
+              required:
+                - userName
+                - relay
+                - port
+              properties:
+                userName:
+                  description: Email to use as login on transactional platform
+                  type: string
+                  format: email
+                  example : 'john.smith@example.com'
+                relay:
+                  description: URL of the SMTP Relay
+                  type: string
+                  example: 'relay.domain.com'
+                port:
+                  description: Port used for SMTP Relay
+                  type: integer
+                  example: 125
+        marketingAutomation:
+          type: object
+          required:
+            - enabled
+          properties:
+            key:
+              description: Marketing Automation Tracker ID
+              type: string
+              example: 'iso05aopqych87ysy0jymf'
+            enabled:
+              description: Status of Marketing Automation Plateform activation for your account (true=enabled, false=disabled)
+              type: boolean
+              example: false
+
+  getAccountActivity:
+      type: object
+      properties:
+        logs:
+          type: array
+          description: Get user activity logs
+          items:
+            required:
+              - action
+              - date
+              - user_email
+              - user_ip
+              - user_agent
+            type: object
+            properties:
+              action:
+                type: string
+                description: Type of activity in the account.
+                example: login-success
+              date:
+                type: string
+                description: Time of the activity.
+                example: '2023-03-27T16:30:00Z'
+              user_email:
+                type: string
+                description: Email address of the user who performed activity in the account.
+                example: 'test@mycompany.com'
+              user_ip:
+                type: string
+                description: IP address of the user who performed activity in the account.
+                example: "192.158.1.38"
+              user_agent:
+                type: string
+                description: Browser details of the user who performed the activity.
+                example: "Mozilla/5.0 (iPad; U; CPU OS 3_2_1 like Mac OS X; en-us)"
+
+  getInvitedUsersList:
+      type: object
+      properties:
+        users:
+          type: array
+          description: Get invited users list
+          items:
+            required:
+              - email
+              - is_owner
+              - status
+              - feature_access
+            type: object
+            properties:
+              email:
+                type: string
+                description: Email address of the user.
+                example: pendingInvitedUser@company.com
+              is_owner:
+                type: string
+                description: Flag for indicating is user owner of the organization.
+                example: true
+              status:
+                type: string
+                description: Status of the invited user.
+                example: 'active'
+              feature_access:
+                description: Feature accessiblity given to the user.
+                type: object
+                properties:
+                  marketing:
+                    description : Marketing features accessiblity.
+                    format: string
+                    example: 'custom'
+                  conversations:
+                    description : Conversations features accessiblity.
+                    format: string
+                    example: 'none'
+                  crm:
+                    description : CRM features accessiblity.
+                    format: string
+                    example: 'full'
+  getCorporateInvitedUsersList:
+      type: object
+      properties:
+        users:
+          type: array
+          description: Get invited users list
+          items:
+            required:
+              - email
+              - groups
+              - is_owner
+              - status
+              - feature_access
+            type: object
+            properties:
+              groups:
+                description: Admin user groups list
+                type: object
+                properties:
+                  id:
+                    description: group id
+                    type: string
+                    example: a5c4f22c08d9ed37ef1ca342
+                  name:
+                    description: group name
+                    type: string
+                    example: My group
+              email:
+                type: string
+                description: Email address of the user.
+                example: master-user@company.com
+              is_owner:
+                type: string
+                description: Flag for indicating is user owner of the organization.
+                example: false
+              status:
+                type: string
+                description: Status of the invited user.
+                example: 'active'
+              feature_access:
+                description: Feature accessiblity given to the user. (Required only if status is active)
+                type: object
+                properties:
+                  user_management:
+                    description : User management accessiblity.
+                    type: array
+                    items:
+                      type: string
+                      example: 'all / none'
+                  api_keys:
+                    description : Api keys accessiblity.
+                    type: array
+                    items:
+                      type: string
+                      example: 'all / none'
+                  my_plan:
+                    description : My plan accessiblity.
+                    type: array
+                    items:
+                      type: string
+                      example: 'all / none'
+                  apps_management:
+                    description : Apps management accessiblity | Not available in ENTv2
+                    type: array
+                    items:
+                      type: string
+                      example: 'all / none'
+                  sub_organization_groups:
+                    description : Group creation, modification or deletion accessibility
+                    type: array
+                    items:
+                      type: string
+                      example: ["create", "edit_delete"]
+                  create_sub_organizations:
+                    description : Authorization to create sub-organization in the admin account. If the user creating the sub-organization, belongs to a group, the user must choose a group at the sub-organization creation.
+                    type: array
+                    items:
+                      type: string
+                      example: 'all / none'
+                  manage_sub_organizations:
+                    description : Authorization to manage and access sub-organizations in the admin account.
+                    type: array
+                    items:
+                      type: string
+                      example: 'all / none'
+                  analytics:
+                    description : Analytics dashboard accessibility
+                    type: array
+                    items:
+                      type: string
+                      example: ["download_data", "create_alerts", "my_looks", "explore_create"]
+                  security:
+                    description : Security page accessibility
+                    type: array
+                    items:
+                      type: string
+                      example: 'all / none'
+  getCorporateUserPermission:
+    type: object
+    description: Check admin user permissions
+    required:
+      - email
+      - status
+      - groups
+      - feature_access
+    properties:
+      email:
+        type: string
+        description: Email address of the user.
+        example: invitedUser@company.com
+      status:
+        type: string
+        description: Status of the invited user.
+        example: 'active / pending'
+      groups:
+        type: array
+        items:
+          type: object
+          description: Groups details
+          properties:
+            id:
+              type: string
+              description: group identifier
+              example: 6cbcxxxxxxxxxxxxxxxx457a
+            name:
+              type: string
+              description: Group name
+              example: Staff
+      feature_access:
+        description: Granular feature permissions given to the user.
+        type: object
+        properties:
+          api_keys:
+            type: array
+            description: Permission on api keys
+            items:
+              type: string
+              description: Permission details
+              example: all
+          my_plan:
+            type: array
+            description: Permission on my plan
+            items:
+              type: string
+              description: Permission details
+              example: all
+          user_management:
+            type: array
+            description: Permission on user management
+            items:
+              type: string
+              description: Permission details
+              example: none
+          apps_management:
+            type: array
+            description: Permission on apps management
+            items:
+              type: string
+              description: Permission details
+              example: all
+          sub_organization_groups:
+              type: array
+              description: Permission on groups
+              items:
+                type: string
+                description: Permission details
+                example: [create, edit_delete]
+          create_sub_organizations:
+            type: array
+            description: Permission on create sub-accounts
+            items:
+              type: string
+              description: Permission details
+              example: all
+          manage_sub_organizations:
+            type: array
+            description: Permission on manage sub-accounts
+            items:
+              type: string
+              description: Permission details
+              example: all
+          analytics:
+            type: array
+            description: Permission on analytics
+            items:
+              type: string
+              description: Permission details
+              example: [create_alerts, download_data, my_looks, explore_create]
+          security:
+            type: array
+            description: Permission on security
+            items:
+              type: string
+              description: Permission details
+              example: all
+  getUserPermission:
+    type: object
+    description: Check user permission
+    required:
+      - email
+      - status
+      - privileges
+    properties:
+      email:
+        type: string
+        description: Email address of the user.
+        example: invitedUser@company.com
+      status:
+        type: string
+        description: Status of the invited user.
+        example: 'active'
+      privileges:
+        description: Granular feature permissions given to the user.
+        type: array
+        items:
+          required:
+            - feature
+            - permissions
+          type: object
+          properties:
+            feature:
+              type: string
+              example: 'Email campaign'
+            permissions:
+              type: array
+              items:
+                type: string
+                example: 'Create / edit / delete'
+
+  putRevokeUserPermission:
+    type: object
+    description: Revoke user permission
+    required:
+      - email
+    properties:
+      email:
+        type: string
+        description: Email address of the user.
+        example: invitedUser@company.com
+
+  putresendcancelinvitation:
+    type: object
+    description: Revoke user permission
+    required:
+      - email
+    properties:
+      email:
+        type: string
+        description: Email address of the user.
+        example: invitedUser@company.com
+
+  inviteAdminUser:
+    type: object
+    required:
+      - email
+      - all_features_access
+      - privileges
+    properties:
+      email:
+        description: Email address for the organization
+        type: string
+        format: email
+        example: inviteuser@example.com
+      all_features_access:
+        description: All access to the features
+        type: boolean
+        example: false
+        enum:
+          - true
+          - false
+      groupIds:
+        description: Ids of Group
+        type: array
+        items:
+          type: string
+          description: Group Id
+        example: ["2baxxxxxxxxxxxxxxxxxxxxxcaa", "65axxxxxxxxxxxxxxxxxxxxxc5a"]
+      privileges:
+        type: array
+        items:
+          type: object
+          description: Privileges given to the user
+          properties:
+            feature:
+              description: Feature name
+              type: string
+              enum:
+                - 'my_plan'
+                - 'api'
+                - 'user_management'
+                - 'app_management'
+                - 'sub_organization_groups'
+                - 'create_sub_organizations'
+                - 'manage_sub_organizations'
+                - 'analytics'
+                - 'security'
+              example: 'user_management'
+            permissions:
+              description: Permissions for a given feature
+              type: array
+              items:
+                type: string
+                enum:
+                  - 'all'
+                  - 'none'
+                  - 'create'
+                  - 'edit_delete'
+                  - 'download_data'
+                  - 'create_alerts'
+                example: "'all', 'none', 'create', 'edit_delete', 'download_data', 'create_alerts'"
+          example: [{"feature": "my_plan", "permissions": ["all"]}, {"feature": "api", "permissions": ["none"]}, {"feature": "user_management", "permissions": ["all"]}, {"feature": "app_management", "permissions": ["all"]}, {"feature": "sub_organization_groups", "permissions": ["create", "edit_delete"]}, {"feature": "create_sub_organizations", "permissions": ["all"]}, {"feature": "manage_sub_organizations", "permissions": ["all"]}, {"feature": "analytics", "permissions": ["download_data", "create_alerts", "my_looks", "explore_create"]}, {"feature": "security", "permissions": ["all"]}]
+
+  inviteuser:
+    type: object
+    required:
+      - email
+      - all_features_access
+      - privileges
+    properties:
+      email:
+        description: Email address for the organization
+        type: string
+        format: email
+        example: inviteuser@example.com
+      all_features_access:
+        description: All access to the features
+        type: boolean
+        example: true
+        enum:
+          - true
+          - false
+      privileges:
+        type: array
+        items:
+          type: object
+          description: Privileges given to the user
+          properties:
+            feature:
+              description: Feature name
+              type: string
+              enum:
+                - 'email_campaigns'
+                - 'sms_campaigns'
+                - 'contacts'
+                - 'templates'
+                - 'workflows'
+                - 'landing_pages'
+                - 'transactional_emails'
+                - 'smtp_api'
+                - 'user_management'
+                - 'sales_platform'
+                - 'phone'
+                - 'conversations'
+                - 'senders_domains_dedicated_ips'
+                - 'push_notifications'
+              example: 'email_campaigns'
+            permissions:
+              description: Permissions for a given feature
+              type: array
+              items:
+                type: string
+                enum:
+                  - 'create_edit_delete'
+                  - 'send_schedule_suspend'
+                  - 'view'
+                  - 'import'
+                  - 'export'
+                  - 'list_and_attributes'
+                  - 'forms'
+                  - 'activate_deactivate'
+                  - 'activate_deactivate_pause'
+                  - 'settings'
+                  - 'schedule_pause'
+                  - 'all'
+                  - 'logs'
+                  - 'access'
+                  - 'assign'
+                  - 'configure'
+                  - 'create_edit_deals'
+                  - "delete_deals"
+                  - 'manage_others_deals_tasks'
+                  - 'manage_owned_companies'
+                  - 'manage_others_companies'
+                  - 'reports'
+                  - 'senders_management'
+                  - 'domains_management'
+                  - 'dedicated_ips_management'
+                  - 'send'
+                  - 'smtp'
+                  - 'api_keys'
+                  - 'authorized_ips'
+                  - 'none'
+                example: "'create_edit_delete', 'send_schedule_suspend'"
+          example: [{"feature": "email_campaigns", "permissions": ["create_edit_delete", "send_schedule_suspend"]},{"feature": "sms_campaigns", "permissions": ["create_edit_delete","send_schedule_suspend"]}]
+
+  getSsoToken:
+    type: object
+    required:
+      - token
+    properties:
+      token:
+        description: Session token, it will remain valid for 15 days.
+        type: 'string'
+        example: 'ede520dxxxxxxxxxxxx76d631fba2'
+
+  getChildDomain:
+    type: object
+    properties:
+      domain:
+        description: Sender domain
+        type: string
+        example: 'mycustomdomain.com'
+      active:
+        description: indicates whether a domain is verified or not
+        type: boolean
+        example: true
+
+  getClient:
+    type: object
+    required:
+      - email
+      - firstName
+      - lastName
+      - companyName
+    properties:
+      email:
+        description: Login Email
+        type: string
+        format: email
+        example: 'john.smith@example.com'
+      firstName:
+        description: First Name
+        type: string
+        example : 'John'
+      lastName:
+        description: Last Name
+        type: string
+        example : 'Smith'
+      companyName:
+        description: Name of the company
+        type: string
+        example: 'MyCompany'
+
+  getExtendedClient:
+    type: object
+    allOf:
+      - $ref: '#/definitions/getClient'
+      - type: object
+        required:
+          - address
+        properties:
+          address:
+            description : Address informations
+            type: object
+            required:
+              - city
+              - street
+              - zipCode
+              - country
+            properties:
+              street:
+                description : Street information
+                type: string
+                example : '47 Harbour Street'
+              city:
+                description : City information
+                type: string
+                example : 'New-York'
+              zipCode:
+                description : Zip Code information
+                type: string
+                example: '9867'
+              country:
+                description : Country information
+                type: string
+                example: 'United States of America'
+
+  getSendersList:
+    type: object
+    properties:
+      senders:
+        description : List of the senders available in your account
+        type: array
+        items:
+          type: object
+          required:
+            - id
+            - name
+            - email
+            - active
+          properties:
+            id:
+              description : Id of the sender
+              type: integer
+              format: int64
+              example: 0
+            name:
+              description : From Name associated to the sender
+              type: string
+              example: 'Marketing'
+            email:
+              description : From Email associated to the sender
+              type: string
+              example: 'marketing@mycompany.com'
+            active:
+              description : Status of sender (true=activated, false=deactivated)
+              type: boolean
+              example: false
+
+            ips:
+              description : List of dedicated IP(s) available in the account. This data is displayed only for dedicated IPs
+              type: array
+              items:
+                type: object
+                required:
+                  - ip
+                  - domain
+                  - weight
+                properties:
+                  ip:
+                    description: Dedicated IP available in your account
+                    type: string
+                    example : '123.98.689.7'
+                  domain:
+                    description: Domain of the IP
+                    type: string
+                    example : 'mycompany.com'
+                  weight:
+                    description : Weight of the IP for this sender
+                    type: integer
+                    format: int64
+                    example: 50
+  getDomainsList:
+      type: object
+      properties:
+        domains:
+          type: array
+          description: List of the domains available in your account
+          items:
+            required:
+              - id
+              - domain_name
+              - authenticated
+              - verified
+            type: object
+            properties:
+              id:
+                type: integer
+                description: Id of the domain
+                format: int64
+                example: 1
+              domain_name:
+                type: string
+                description: Domain name
+                example: mycompany.com
+              authenticated:
+                type: boolean
+                description: Status of domain authentication (true=authenticated, false=non authenticated)
+                example: true
+              verified:
+                type: boolean
+                description: Status of domain verification (true=verified, false=non verified)
+                example: false
+              ip:
+                type: string
+                description: Dedicated IP associated with domain
+                example: 123.98.689.7
+
+  createChild:
+    type: object
+    required:
+      - email
+      - firstName
+      - lastName
+      - companyName
+      - password
+    properties:
+      email:
+        description: Email address to create the child account
+        type: string
+        format: email
+        example: 'josh.cruise@example.com'
+      firstName:
+        type: string
+        description: First name to use to create the child account
+        example: 'Josh'
+      lastName:
+        type: string
+        description: Last name to use to create the child account
+        example: 'Cruise'
+      companyName:
+        type: string
+        description: Company name to use to create the child account
+        example: 'Your Company'
+      password:
+        type: string
+        format: password
+        description: Password for the child account to login
+        example: 'Pa55w0rd65'
+      language:
+        description: Language of the child account
+        enum:
+          - fr
+          - es
+          - pt
+          - it
+          - de
+          - en
+        type: string
+        example: 'en'
+
+  createSender:
+    type: object
+    required:
+      - name
+      - email
+    properties:
+      name:
+        type: string
+        description: From Name to use for the sender
+        example: 'Newsletter'
+      email:
+        type: string
+        format: email
+        description: From email to use for the sender. A verification email will be sent to this address.
+        example: 'newsletter@mycompany.com'
+      ips:
+        type: array
+        description:  Mandatory in case of dedicated IP, IPs to associate to the sender
+        items:
+          type: object
+          required:
+            - ip
+            - domain
+          properties:
+            ip:
+              description: Dedicated IP available in your account
+              type: string
+              example : '123.98.689.7'
+            domain:
+              description: Domain of the IP
+              type: string
+              example : 'mycompany.com'
+            weight:
+              description: Weight to apply to the IP. Sum of all IP weights must be 100. Should be passed for either ALL or NONE of the IPs. If it's not passed, the sending will be equally balanced on all IPs.
+              type: integer
+              format: int64
+              maximum: 100
+              minimum: 1
+              example: 50
+
+  updateSender:
+    type: object
+    properties:
+      name:
+        type: string
+        description: From Name to update the sender
+        example: 'Newsletter'
+      email:
+        type: string
+        format: email
+        description: From Email to update the sender
+        example: 'newsletter@mycompany.com'
+      ips:
+        type: array
+        description: Only in case of dedicated IP, IPs to associate to the sender. If passed, will replace all the existing IPs.
+        items:
+          type: object
+          required:
+            - ip
+            - domain
+          properties:
+            ip:
+              description: Dedicated IP available in your account
+              type: string
+              example : '123.98.689.7'
+            domain:
+              description: Domain of the IP
+              type: string
+              example : 'mycompany.com'
+            weight:
+              description: Weight to apply to the IP. Sum of all IP weights must be 100. Should be passed for either ALL or NONE of the IPs. If it's not passed, the sending will be equally balanced on all IPs.
+              type: integer
+              format: int64
+              maximum: 100
+              minimum: 1
+              example: 50
+  otp:
+    required:
+      - otp
+    type: object
+    properties:
+      name:
+        type: integer
+        description: 6 digit OTP received on email
+        example: 123456
+  createDomain:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string
+          description: Domain name
+          example: mycompany.com
+
+  updateChild:
+    type: object
+    properties:
+      email:
+        type: string
+        format: email
+        description: New Email address to update the child account
+        example: 'josh.cruise@example.com'
+      firstName:
+        type: string
+        description: New First name to use to update the child account
+        example: 'Josh'
+      lastName:
+        type: string
+        description: New Last name to use to update the child account
+        example: 'Cruise'
+      companyName:
+        type: string
+        description: New Company name to use to update the child account
+        example: 'Your Company'
+      password:
+        type: string
+        format: password
+        description: New password for the child account to login
+        example: 'Pa55w0rd65'
+
+  errorModel:
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: string
+        enum:
+          - invalid_parameter
+          - missing_parameter
+          - out_of_range
+          - campaign_processing
+          - campaign_sent
+          - document_not_found
+          - not_enough_credits
+          - permission_denied
+          - duplicate_parameter
+          - duplicate_request
+          - method_not_allowed
+          - unauthorized
+          - account_under_validation
+          - not_acceptable
+          - bad_request
+          - unprocessable_entity
+        description: Error code displayed in case of a failure
+        example: 'method_not_allowed'
+      message:
+        type: string
+        description: Readable message associated to the failure
+        example: 'POST Method is not allowed on this path'
+
+  errorModelWithStatus:
+      type: object
+      required:
+      - error
+      properties:
+        error:
+          type: object
+          required:
+          - code
+          - message
+          - status
+          properties:
+            code:
+              type: string
+              description: Error code capitalized in case of a failure
+              example: INVALID_EMAIL
+            message:
+              type: string
+              description: Readable message associated to the failure
+              example: The specified email address is not valid
+            status:
+              type: integer
+              description: Status code of the error
+              example: 400
+
+  contactErrorModel:
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: string
+        enum:
+          - invalid_parameter
+          - missing_parameter
+          - document_not_found
+          - account_in_process
+          - duplicate_parameter
+          - method_not_allowed
+          - out_of_range
+        description: Error code displayed in case of a failure
+        example: 'duplicate_parameter'
+      message:
+        type: string
+        description: Readable message associated to the failure
+        example: 'email is already associated with another Contact'
+      metadata:
+        type: object
+        description: Additional information about the error
+        example: { duplicate_identifiers: [ 'email' ] }
+
+  addChildDomain:
+    type: object
+    properties:
+      domain:
+        description: Sender domain to add for a specific child account
+        type: string
+        example: 'mychilddomain.com'
+
+  getProcesses:
+    type: object
+    properties:
+      processes:
+        description: List of processes available on your account
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/getProcess'
+      count:
+        type: integer
+        format: int64
+        description : Number of processes available on your account
+        example: 5
+
+  getProcess:
+    type: object
+    required:
+      - id
+      - status
+      - name
+    properties:
+      id:
+         type: integer
+         format: int64
+         description: Id of the process
+         example: 145
+      status:
+         type: string
+         enum :
+          - queued
+          - in_process
+          - completed
+         description: Status of the process
+         example: 'queued'
+      name:
+         type: string
+         description: Process name
+         example: 'IMPORTUSER'
+      export_url:
+         type: string
+         description: URL on which send export the of contacts once the process is completed
+         example: 'http://requestb.in/16ua3aj1'
+
+  getEmailCampaigns:
+    type: object
+    properties:
+      campaigns:
+        type: array
+        items:
+          type: object
+          allOf:
+            - $ref: '#/definitions/getExtendedCampaignOverview'
+            - type: object
+              required:
+                - recipients
+                - statistics
+              properties:
+                recipients:
+                  allOf:
+                   - $ref: '#/definitions/getCampaignRecipients'
+                statistics:
+                  allOf:
+                  - $ref: '#/definitions/getExtendedCampaignStats'
+                shareLink:
+                  type: string
+                  format: url
+                  description: Link to share the campaign on social medias
+                  example: 'http://dhh.brevo.com/fhsgccc.html?t=9865448900'
+      count:
+        type: integer
+        format: int64
+        description: Number of Email campaigns retrieved
+        example: 24
+
+  getSmsCampaigns:
+    type: object
+    properties:
+      campaigns:
+        type: array
+        items:
+          type: object
+          allOf:
+            - $ref: '#/definitions/getSmsCampaignOverview'
+            - type: object
+              required:
+                - recipients
+                - statistics
+              properties:
+                recipients:
+                  allOf:
+                    - $ref: '#/definitions/getCampaignRecipients'
+                statistics:
+                  allOf:
+                    - $ref: '#/definitions/getSmsCampaignStats'
+      count:
+        type: integer
+        format: int64
+        description: Number of SMS campaigns retrieved
+        example: 12
+
+  getSmsCampaign:
+    allOf:
+      - $ref: '#/definitions/getSmsCampaignOverview'
+      - type: object
+        required:
+          - recipients
+          - statistics
+        properties:
+          recipients:
+            type: object
+            allOf:
+              - $ref: '#/definitions/getCampaignRecipients'
+          statistics:
+            type: object
+            allOf:
+              - $ref: '#/definitions/getSmsCampaignStats'
+
+  getEmailCampaign:
+    allOf:
+      - $ref: '#/definitions/getExtendedCampaignOverview'
+      - type: object
+        required:
+          - recipients
+          - statistics
+        properties:
+          recipients:
+            type: object
+            allOf:
+              - $ref: '#/definitions/getCampaignRecipients'
+          statistics:
+            type: object
+            allOf:
+              - $ref: '#/definitions/getExtendedCampaignStats'
+
+  getCampaignOverview:
+    type: object
+    required:
+     - id
+     - name
+     - type
+     - status
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the campaign
+        example : 12
+      name:
+        type: string
+        description: Name of the campaign
+        example : 'EN - Sales Summer 2017'
+      subject:
+        type: string
+        description: Subject of the campaign. Only available if `abTesting` flag of the campaign is `false`
+        example : '20% OFF for 2017 Summer Sales'
+      previewText:
+        type: string
+        description : Preview text or preheader of the email campaign
+        example: Thanks for your order!
+      type:
+        type: string
+        enum:
+          - classic
+          - trigger
+        description: Type of campaign
+        example: 'classic'
+      status:
+        type: string
+        enum:
+          - draft
+          - sent
+          - archive
+          - queued
+          - suspended
+          - in_process
+        description: Status of the campaign
+        example: 'sent'
+      scheduledAt:
+        type: string
+        description: UTC date-time on which campaign is scheduled (YYYY-MM-DDTHH:mm:ss.SSSZ)
+        example : '2017-06-01T12:30:00Z'
+      abTesting:
+        description: Status of A/B Test for the campaign. abTesting = false means it is disabled, & abTesting = true means it is enabled.
+        type: boolean
+        example: true
+      subjectA:
+        description: Subject A of the ab-test campaign. Only available if `abTesting` flag of the campaign is `true`
+        type: string
+        example: 'Discover the New Collection!'
+      subjectB:
+        description: Subject B of the ab-test campaign. Only available if `abTesting` flag of the campaign is `true`
+        type: string
+        example: 'Want to discover the New Collection?'
+      splitRule:
+        description: The size of your ab-test groups. Only available if `abTesting` flag of the campaign is `true`
+        type: integer
+        example: 25
+      winnerCriteria:
+        description: Criteria for the winning version. Only available if `abTesting` flag of the campaign is `true`
+        type: string
+        example: 'open'
+      winnerDelay:
+        description: The duration of the test in hours at the end of which the winning version will be sent. Only available if `abTesting` flag of the campaign is `true`
+        type: integer
+        example: 50
+      sendAtBestTime:
+        type: boolean
+        description: It is true if you have chosen to send your campaign at best time, otherwise it is false
+        example: true
+
+  getExtendedCampaignOverview:
+    allOf:
+      - $ref: '#/definitions/getCampaignOverview'
+      - type: object
+        required:
+         - testSent
+         - header
+         - footer
+         - sender
+         - replyTo
+         - htmlContent
+         - createdAt
+         - modifiedAt
+        properties:
+          utmCampaignValue:
+            type: string
+            description: utm parameter associated with campaign
+            example: myutm
+          utmSource:
+            type: string
+            description: source of utm parameter
+            example: Brevo
+          utmMedium:
+            type: string
+            description: medium parameter
+            example: EMAIL
+          utmID:
+            type: integer
+            description: utm id
+            example: 10
+          testSent:
+            type: boolean
+            description: Retrieved the status of test email sending. (true=Test email has been sent  false=Test email has not been sent)
+            example: true
+          header:
+            type: string
+            description: Header of the campaign
+            example: '[DEFAULT_HEADER]'
+          footer:
+            type: string
+            description: Footer of the campaign
+            example: '[DEFAULT_FOOTER]'
+          sender:
+            type: object
+            properties:
+              name:
+                description:  Sender name of the campaign
+                type: string
+                example: 'Marketing'
+              email:
+                description: Sender email of the campaign
+                type: string
+                format: email
+                example: 'marketing@mycompany.com'
+              id:
+                description: Sender id of the campaign
+                type: integer
+                format: int64
+                example: 43
+          replyTo:
+            type: string
+            format: email
+            description: Email defined as the "Reply to" of the campaign
+            example: 'replyto@domain.com'
+          toField:
+            type: string
+            description: Customisation of the "to" field of the campaign
+            example: '{FNAME} {LNAME}'
+          htmlContent:
+            type: string
+            description: HTML content of the campaign
+            example: 'This is my HTML Content'
+          shareLink:
+            type: string
+            format: url
+            description: Link to share the campaign on social medias
+            example: 'http://dhh.brevo.com/fhsgccc.html?t=9865448900'
+          tag:
+            type: string
+            description: Tag of the campaign
+            example: 'Newsletter'
+          createdAt:
+            type: string
+            description: Creation UTC date-time of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ)
+            example: '2017-05-01T12:30:00Z'
+          modifiedAt:
+            type: string
+            description: UTC date-time of last modification of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ)
+            example: '2017-05-01T12:30:00Z'
+          inlineImageActivation:
+            type: boolean
+            description: Status of inline image. inlineImageActivation = false means image can’t be embedded, & inlineImageActivation = true means image can be embedded, in the email.
+            example: true
+          mirrorActive:
+            type: boolean
+            description: Status of mirror links in campaign. mirrorActive = false means mirror links are deactivated, & mirrorActive = true means mirror links are activated, in the campaign
+            example: true
+          recurring:
+            description : FOR TRIGGER ONLY ! Type of trigger campaign.recurring = false means contact can receive the same Trigger campaign only once, & recurring = true means contact can receive the same Trigger campaign several times
+            type: boolean
+            example: true
+          sentDate:
+            type: string
+            description: Sent UTC date-time of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ). Only available if 'status' of the campaign is 'sent'
+            example: '2018-12-01T16:30:00Z'
+          returnBounce:
+            description: Total number of non-delivered campaigns for a particular campaign id.
+            type: integer
+            format: int64
+            example: 5
+
+  getCampaignRecipients:
+     type: object
+     required:
+      - lists
+      - exclusionLists
+     properties:
+      lists:
+        type: array
+        items:
+          type: integer
+          format: int64
+          description: List IDs included in the campaign
+          example: 21
+      exclusionLists:
+        type: array
+        items:
+          type: integer
+          format: int64
+          description: List IDs excluded of the campaign
+          example: 13
+
+  getExtendedCampaignStats:
+     type: object
+     required:
+      - globalStats
+      - campaignStats
+      - mirrorClick
+      - remaining
+      - linksStats
+      - statsByDomain
+      - statsByDevice
+      - statsByBrowser
+     properties:
+      globalStats:
+        type: object
+        description: Overall statistics of the campaign
+        allOf:
+          - $ref: '#/definitions/getCampaignStats'
+      campaignStats:
+        type: array
+        description: List-wise statistics of the campaign.
+        items:
+          type: object
+          allOf:
+            - $ref: '#/definitions/getCampaignStats'
+      mirrorClick:
+        type: integer
+        format: int64
+        description: Number of clicks on mirror link
+        example: 120
+      remaining:
+        type: integer
+        format: int64
+        description: Number of remaning emails to send
+        example: 1000
+      linksStats:
+        type: object
+        description: Statistics about the number of clicks for the links
+        example: {"example.abc.com": 7, "example.domain.com": 10}
+      statsByDomain:
+        $ref: '#/definitions/getStatsByDomain'
+      statsByDevice:
+        description: Statistics about the campaign on the basis of various devices
+        $ref: '#/definitions/getStatsByDevice'
+      statsByBrowser:
+        description: Statistics about the campaign on the basis of various browsers
+        $ref: '#/definitions/getStatsByBrowser'
+
+  getStatsByDomain:
+    type: object
+    additionalProperties:
+      $ref: '#/definitions/getCampaignStats'
+
+  getStatsByDevice:
+    type: object
+    properties:
+      desktop:
+        type: object
+        description: Statistics of the campaign on the basis of desktop devices
+        additionalProperties:
+          $ref: '#/definitions/getDeviceBrowserStats'
+      mobile:
+        type: object
+        description: Statistics of the campaign on the basis of mobile devices
+        additionalProperties:
+          $ref: '#/definitions/getDeviceBrowserStats'
+      tablet:
+        type: object
+        description: Statistics of the campaign on the basis of tablet devices
+        additionalProperties:
+          $ref: '#/definitions/getDeviceBrowserStats'
+      unknown:
+        type: object
+        description: Statistics of the campaign on the basis of unknown devices
+        additionalProperties:
+          $ref: '#/definitions/getDeviceBrowserStats'
+
+  getStatsByBrowser:
+    type: object
+    additionalProperties:
+      $ref: '#/definitions/getDeviceBrowserStats'
+
+  addContactToList:
+    type: object
+    properties:
+      emails:
+        description: Mandatory if IDs, EXT_ID attributes are not passed, ignored otherwise. Emails to add to a list. You can pass a maximum of 150 emails for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api.
+        type: array
+        minItems: 1
+        maxItems: 150
+        items:
+          type: string
+          format: email
+          description: Emails addresses OR IDs of the contacts
+          example: 'john.smith@contact.com'
+      ids:
+        description: Mandatory if Emails, EXT_ID attributes are not passed, ignored otherwise. Emails to add to a list. You can pass a maximum of 150 ids for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api.
+        type: array
+        minItems: 1
+        maxItems: 150
+        items:
+          type: integer
+          format: int64
+          description: IDs of the contacts
+          example: 121
+      extIds:
+        description: Mandatory if Emails, IDs are not passed, ignored otherwise. Emails to add to a list. You can pass a maximum of 150 extIds for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api.
+        maxItems: 150
+        minItems: 1
+        type: array
+        items:
+          type: string
+          description: EXT_ID to add to a list
+          example: ext132
+
+  removeContactFromList:
+    type: object
+    properties:
+      emails:
+        description: "Required if 'all' is false and EXT_ID attributes, IDs are not passed. Emails to remove from a list. You can pass a maximum of 150 emails for removal in one request."
+        type: array
+        minItems: 1
+        maxItems: 150
+        items:
+          type: string
+          description: Emails addresses of the contacts
+          example: 'john.smith@contact.com OR 151'
+      ids:
+        description: Mandatory if Emails, EXT_ID attributes are not passed, ignored otherwise. Contact IDs to add to a list. You can pass a maximum of 150 Ids for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api.
+        type: array
+        minItems: 1
+        maxItems: 150
+        items:
+          type: integer
+          format: int64
+          description: IDs of the contacts
+          example: 121
+      extIds:
+        description: Mandatory if 'all' is false and Emails, IDs are not passed, ignored otherwise. EXT_ID attributes to add to a list. You can pass a maximum of 150 extIds for addition in one request. If you need to add the emails in bulk, please prefer /contacts/import api.
+        maxItems: 150
+        minItems: 1
+        type: array
+        items:
+          type: string
+          description: EXT_ID to add to a list
+          example: ext132
+      all:
+        description: "Required if none of 'emails', EXT_ID attributes or 'ids' are passed. Remove all existing contacts from a list.  A process will be created in this scenario. You can fetch the process details to know about the progress"
+        type: boolean
+        example: false
+
+  getSmsCampaignOverview:
+    type: object
+    required:
+     - id
+     - name
+     - status
+     - content
+     - sender
+     - createdAt
+     - modifiedAt
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the SMS Campaign
+        example: 2
+      name:
+        type: string
+        description: Name of the SMS Campaign
+        example: 'PROMO CODE'
+      status:
+        type: string
+        enum:
+          - draft
+          - sent
+          - archive
+          - queued
+          - suspended
+          - inProcess
+        description: Status of the SMS Campaign
+        example: 'draft'
+      content:
+        type: string
+        description: Content of the SMS Campaign
+        example: 'Visit our Store and get some discount !'
+      scheduledAt:
+        type: string
+        description: UTC date-time on which SMS campaign is scheduled. Should be in YYYY-MM-DDTHH:mm:ss.SSSZ format
+        example : '2017-06-01T12:30:00Z'
+      sender:
+        type: string
+        description: Sender of the SMS Campaign
+        example: 'MyCompany'
+      createdAt:
+        type: string
+        description: Creation UTC date-time of the SMS campaign (YYYY-MM-DDTHH:mm:ss.SSSZ)
+        example: '2017-06-01T12:30:00Z'
+      modifiedAt:
+        type: string
+        description: UTC date-time of last modification of the SMS campaign (YYYY-MM-DDTHH:mm:ss.SSSZ)
+        example: '2017-05-01T12:30:00Z'
+  getWhatsappCampaignOverview:
+      required:
+      - id
+      - campaignName
+      - campaignStatus
+      - senderNumber
+      - recipients
+      - createdAt
+      - template
+      - modifiedAt
+      type: object
+      properties:
+        id:
+          type: integer
+          description: ID of the WhatsApp Campaign
+          format: int64
+          example: 1672035851100690
+        campaignName:
+          type: string
+          description: Name of the WhatsApp Campaign
+          example: Test Campaign
+        campaignStatus:
+          type: string
+          description: Status of the WhatsApp Campaign
+          example: draft
+          enum:
+          - draft
+          - scheduled
+          - pending
+          - approved
+          - running
+          - suspended
+          - rejected
+          - sent
+        scheduledAt:
+          type: string
+          description: UTC date-time on which WhatsApp campaign is scheduled. Should be
+            in YYYY-MM-DDTHH:mm:ss.SSSZ format
+          example: 2017-06-01T12:30:00Z
+        senderNumber:
+          type: string
+          description: Sender of the WhatsApp Campaign
+          example: 9368207029
+        stats :
+          $ref: '#/definitions/WhatsappCampStats'
+        template :
+          $ref: '#/definitions/WhatsappCampTemplate'
+        createdAt:
+          type: string
+          description: Creation UTC date-time of the WhatsApp campaign (YYYY-MM-DDTHH:mm:ss.SSSZ)
+          example: 2017-06-01T12:30:00Z
+        modifiedAt:
+          type: string
+          description: UTC date-time of last modification of the WhatsApp campaign (YYYY-MM-DDTHH:mm:ss.SSSZ)
+          example: 2017-05-01T12:30:00Z
+  WhatsappCampStats:
+      type: object
+      required:
+      - sent
+      - delivered
+      - read
+      - unsubscribe
+      - not_sent
+      properties:
+       sent:
+           type: integer
+           example: 3
+       delivered:
+           type: integer
+           example : 3
+       read:
+            type: integer
+            example: 2
+       unsubscribe:
+            type: integer
+            example: 0
+       not_sent:
+            type: integer
+            example: 4
+  WhatsappCampTemplate:
+      type: object
+      properties:
+       name:
+           type : string
+           example: wta107
+           description : name of the template
+       category:
+           type : string
+           example : Marketing
+           description : description of the template
+       language:
+           type : string
+           example : en_GB
+           description : language of the template
+       contains_button:
+           type : boolean
+           example : false
+       display_header:
+           type : boolean
+           example : true
+       header_type:
+           type : string
+           example : text
+           description : type of header
+       components:
+           type : array
+           description : array of component item objects
+           items:
+            $ref: '#/definitions/componentItems'
+       header_variables :
+           type : array
+           description : array of variables item object
+           items:
+            $ref: '#/definitions/variablesItems'
+       body_variables:
+           type : array
+           description: array of variables item variables
+           items:
+            $ref: '#/definitions/variablesItems'
+       button_type:
+           type: string
+           example : QUICK_REPLIES
+       hide_footer:
+           type: boolean
+           example : true
+  componentItems :
+      type : object
+      properties:
+       type :
+          type : string
+          example : BODY
+       text :
+          type : string
+          example : Life is a long lesson in humility
+  variablesItems :
+      type : object
+      properties :
+       name :
+         type: string
+         example : FIRSTNAME
+       default :
+         type : string
+         example : INVALID_HEADER
+       datatype :
+         type : string
+         example : text
+  bodyVariablesItems :
+      type : object
+  getWATemplates :
+    type: object
+    required:
+      - templates
+      - count
+    properties :
+      templates:
+        type: array
+        items:
+          type: object
+          required:
+          - id
+          - name
+          - status
+          - category
+          - language
+          - createdAt
+          - modifiedAt
+          properties :
+            id:
+              type: string
+              description: id of the template
+              example: 235
+            name:
+              type: string
+              description: Name of the WhatsApp template
+              example: Test template
+            status:
+              type: string
+              description: Status of the WhatsApp template
+              example: approved
+            language:
+              type : string
+              description: Language in which template exists
+              example : en
+            category:
+              type: string
+              description : category of the template
+              example: MARKETING
+            errorReason:
+              type: string
+              description: Error reason in the template creation
+              example: NONE
+            createdAt:
+              type: string
+              description: Creation UTC date-time of the whatsApp template (YYYY-MM-DDTHH:mm:ss.SSSZ)
+              example: 2017-06-01T12:30:00Z
+            modifiedAt:
+              type: string
+              description: UTC date-time of last modification of the whatsApp template (YYYY-MM-DDTHH:mm:ss.SSSZ)
+              example: 2017-05-01T12:30:00Z
+      count:
+        type: integer
+        format: int64
+        description : Number of whatsApp templates retrived
+        example: 24
+  getWhatsappCampaigns:
+    type: object
+    properties :
+      campaigns :
+        type: array
+        items:
+          type: object
+          required:
+          - id
+          - campaignName
+          - campaignStatus
+          - templateId
+          - scheduledAt
+          - createdAt
+          - modifiedAt
+          properties :
+            id:
+              type: integer
+              description: ID of the WhatsApp Campaign
+              format: int64
+              example: 1672035851100690
+            campaignName:
+              type: string
+              description: Name of the WhatsApp Campaign
+              example: Test Campaign
+            templateId:
+                type : string
+                description : Id of the WhatsApp template
+                example : 637660278078655
+            campaignStatus:
+                type: string
+                description: Status of the WhatsApp Campaign
+                example: draft
+                enum:
+                - draft
+                - scheduled
+                - pending
+                - approved
+                - running
+                - suspended
+                - rejected
+                - sent
+            scheduledAt:
+                type: string
+                description: UTC date-time on which WhatsApp campaign is scheduled. Should be in YYYY-MM-DDTHH:mm:ss.SSSZ format
+                example: 2017-06-01T12:30:00Z
+            errorReason:
+              type: string
+              description: Error reason in the campaign creation
+              example: NONE
+            invalidatedContacts :
+                type : integer
+                description : Count of invalidated contacts
+                format : int64
+                example : 0
+            readPercentage :
+                type : number
+                description : Read percentage of the the WhatsApp campaign created
+                format : float
+                example : 28.57
+            stats :
+                $ref: '#/definitions/WhatsappCampStats'
+            createdAt:
+              type: string
+              description: Creation UTC date-time of the WhatsApp campaign (YYYY-MM-DDTHH:mm:ss.SSSZ)
+              example: 2017-06-01T12:30:00Z
+            modifiedAt:
+              type: string
+              description: UTC date-time of last modification of the whatsapp template (YYYY-MM-DDTHH:mm:ss.SSSZ)
+              example: 2017-05-01T12:30:00Z
+      count:
+        type: integer
+        format: int64
+        description : Number of WhatsApp campaigns retrived
+        example: 24
+  createWhatsAppCampaign :
+    type : object
+    required :
+    - name
+    - templateId
+    - scheduledAt
+    - recipients
+    properties :
+       name :
+         type : string
+         description : Name of the WhatsApp campaign creation
+         example : Test Campaign
+       templateId :
+         type : integer
+         description : Id of the WhatsApp template in **approved** state
+         example : 19
+       scheduledAt :
+         type: string
+         description: |
+            Sending UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). **Prefer to pass your timezone in date-time format for accurate result.For example: **2017-06-01T12:30:00+02:00**
+         example: 2017-06-01T12:30:00+02:00
+       recipients:
+         type: object
+         description: Segment ids and List ids to include/exclude from campaign
+         properties:
+          excludedListIds :
+            type: array
+            description: List ids to exclude from the campaign
+            items:
+              type: integer
+              format: int64
+              example: 8
+          listIds:
+            type: array
+            description: |
+              **Mandatory if scheduledAt is not empty**. List Ids to send the campaign to
+            items:
+              type: integer
+              format: int64
+              example: 32
+          segments:
+            description: |
+              **Mandatory if listIds are not used**. Segment ids to send the campaign to.
+            type: array
+            items:
+              type: integer
+              format: int64
+              example: 23
+  getWhatsAppConfig :
+      type : object
+      properties :
+       whatsappBusinessAccountId :
+         type : string
+         description : Id of the WhatsApp business account
+         example : 105569359072383
+       sendingLimit :
+         type : string
+         description : Sending limit Information of the WhatsApp API account
+         example : TIER_1K
+       phoneNumberQuality :
+         type : string
+         description : Quality status of phone number associated with WhatsApp account. There are three quality ratings. example - **High (GREEN) , Medium (YELLOW) and Low(RED)**
+         example : GREEN
+         enum :
+         - GREEN
+         - YELLOW
+         - RED
+       whatsappBusinessAccountStatus :
+         type : string
+         description : Status information related to WhatsApp Api account
+         example : APPROVED
+       businessStatus :
+         type : string
+         description : Verification status information of the Business account
+         example : verified
+       phoneNumberNameStatus :
+         type : string
+         description : Status of the name associated with WhatsApp Phone number
+         example : APPROVED
+         enum :
+         - APPROVED
+         - PENDING
+         - REJECTED
+  createWhatsAppTemplate :
+      type : object
+      required :
+      - name
+      - language
+      - category
+      - bodyText
+      properties :
+        name:
+          type : string
+          description : Name of the template
+          example : Test template
+        language :
+          type : string
+          description : |
+                Language of the template. For Example :
+                **en** for English
+          example : en
+        category :
+          type : string
+          description : Category of the template
+          example : MARKETING
+          enum :
+          - MARKETING
+          - UTILITY
+        mediaUrl:
+          type : string
+          description : |
+                      Absolute url of the media file **(no local file)** for the header. **Use this field in you want to add media in Template header and headerText is empty.**
+                      Allowed extensions for media files are:
+                      #### jpeg | png | mp4 | pdf
+          example : https://attachment.domain.com
+        bodyText :
+          type : string
+          description : Body of the template. **Maximum allowed characters are 1024**
+          example : making it look like readable English
+        headerText :
+          type : string
+          description : |
+                     Text content of the header in the template.  **Maximum allowed characters are 45**
+                     **Use this field to add text content in template header and if mediaUrl is empty**
+          example : Test WhatsApp Campaign
+        source :
+          type : string
+          description : source of the template
+          enum :
+          - Automation
+          - Conversations
+  updateWhatsAppCampaign :
+      type: object
+      properties :
+        campaignName:
+          type: string
+          description : Name of the campaign
+          example : Test WhatsApp
+        campaignStatus :
+          type : string
+          description : Status of the campaign
+          example : scheduled
+          enum :
+          - scheduled
+          - suspended
+          default : scheduled
+        rescheduleFor :
+          type : string
+          description : |
+            Reschedule the sending UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) of campaign. **Prefer to pass your timezone in date-time format for accurate result.For example: **2017-06-01T12:30:00+02:00**
+            Use this field to update the scheduledAt of any existing draft or scheduled WhatsApp campaign.
+          example: 2017-06-01T12:30:00+02:00
+        recipients:
+          type: object
+          properties:
+            excludedListIds :
+              type: array
+              description: List ids to exclude from the campaign
+              items:
+                type: integer
+                format: int64
+                example: 8
+            listIds:
+              type: array
+              description: |
+                **Mandatory if scheduledAt is not empty**. List Ids to send the campaign to
+              items:
+                type: integer
+                format: int64
+                example: 32
+            segments:
+              description: |
+                **Mandatory if listIds are not used**. Segment ids to send the campaign to.
+              type: array
+              items:
+                type: integer
+                format: int64
+                example: 23
+          description: Segment ids and List ids to include/exclude from campaign
+  subscriptionAggregateBalance:
+    properties:
+      balanceDefinitionId:
+        description: Unique identifier for the balance definition).
+        type: string
+      value:
+        description: The amount of the balance.
+        type: number
+    type: object
+  subscriptionBalances:
+    properties:
+      balances:
+        description: List of balance details associated with the contact.
+        items:
+          $ref: '#/definitions/subscriptionAggregateBalance'
+        type: array
+      contactId:
+        description: Unique identifier of the contact.
+        type: integer
+      loyaltyProgramId:
+        description: Unique identifier of the loyalty program.
+        type: string
+    type: object
+  subscriptionAttributedReward:
+    properties:
+      code:
+        description: Reward code assigned to the contact.
+        type: string
+      contactId:
+        description: Unique identifier of the contact.
+        type: integer
+      createdAt:
+        description: Timestamp when the reward was created.
+        type: string
+      expirationDate:
+        description: Expiration date of the reward.
+        type: string
+      id:
+        description: Unique identifier of the reward.
+        type: string
+      loyaltyProgramId:
+        description: Unique identifier of the loyalty program.
+        type: string
+      meta:
+        additionalProperties: {}
+        description: Additional metadata related to the reward.
+        type: object
+      rewardId:
+        description: Unique identifier of the reward definition.
+        type: string
+      updatedAt:
+        description: Timestamp when the reward was last updated.
+        type: string
+    type: object
+  subscriptionTier:
+    properties:
+      contactId:
+        description: Unique identifier of the contact.
+        type: integer
+      createdAt:
+        description: Timestamp when the tier was assigned.
+        type: string
+      groupId:
+        description: Unique identifier of the group associated with the tier.
+        type: string
+      loyaltyProgramId:
+        description: Unique identifier of the loyalty program.
+        type: string
+      meta:
+        additionalProperties: {}
+        description: Additional metadata related to the tier.
+        type: object
+      tierId:
+        description: Unique identifier of the tier.
+        type: string
+      updatedAt:
+        description: Timestamp when the tier was last updated
+        type: string
+    type: object
+  subscriptionHandlerInfo:
+    properties:
+      balance:
+        allOf:
+        - $ref: '#/definitions/subscriptionBalances'
+        description: Balance details for the subscription.
+      members:
+        description: List of members associated with the subscription.
+        items:
+          $ref: '#/definitions/memberContact'
+        type: array
+      reward:
+        description: List of rewards associated with the subscription.
+        items:
+          $ref: '#/definitions/subscriptionAttributedReward'
+        type: array
+      tier:
+        description: List of tier assignments for the subscription.
+        items:
+          $ref: '#/definitions/subscriptionTier'
+        type: array
+    type: object
+  memberContact:
+    properties:
+      createdAt:
+        description: Timestamp when the member was created.
+        type: string
+      memberContactId:
+        description: Unique identifier of the member.
+        type: integer
+      updatedAt:
+        description: Timestamp when the member was last updated.
+        type: string
+    type: object
+  subscriptionMember:
+    properties:
+      createdAt:
+        description: Timestamp when the subscription member was created.
+        type: string
+      memberContactIds:
+        description: List of unique member contact IDs.
+        items:
+          type: integer
+        type: array
+      organizationId:
+        description: Unique identifier of the organization.
+        type: integer
+      ownerContactId:
+        description: Unique identifier of the subscription owner.
+        type: integer
+      updatedAt:
+        description: Timestamp when the subscription member was last updated.
+        type: string
+    type: object
+  subscription:
+    properties:
+      contactId:
+        description: Unique identifier of the contact.
+        type: integer
+      createdAt:
+        description: Timestamp when the subscription was created.
+        type: string
+      loyaltyProgramId:
+        description: Unique identifier of the loyalty program.
+        type: string
+      loyaltySubscriptionId:
+        description: Unique identifier of the subscription.
+        type: string
+      organizationId:
+        description: Unique identifier of the organization.
+        type: integer
+      updatedAt:
+        description: Timestamp when the subscription was last updated.
+        type: string
+      versionId:
+        description: Version number of the subscription.
+        type: integer
+    type: object
+  addSubscriptionMemberPayload:
+    properties:
+      contactId:
+        description: Required if LoyaltySubscriptionId is not provided, must
+          be greater than 0
+        type: integer
+      loyaltySubscriptionId:
+        description: Required if ContactId is not provided, max length 64
+        maxLength: 64
+        type: string
+      memberContactIds:
+        description: Required, each item must be greater than or equal to 1
+        items:
+          type: integer
+        minItems: 1
+        type: array
+    required:
+    - memberContactIds
+    type: object
+  createLoyaltyProgramPayload:
+    properties:
+      description:
+        description: Optional description of the loyalty program (max 256 chars).
+        maxLength: 256
+        type: string
+      documentId:
+        description: Optional unique document ID.
+        type: string
+      meta:
+        additionalProperties: {}
+        description: Optional metadata related to the loyalty program.
+        type: object
+      name:
+        description: Required name of the loyalty program (max 128 chars).
+        maxLength: 128
+        type: string
+    required:
+    - name
+    type: object
+  createSubscriptionPayload:
+    properties:
+      contactId:
+        description: Required contact ID; must be greater than 0.
+        type: integer
+      creationDate:
+        description: Optional custom date-time format.
+        type: string
+      loyaltySubscriptionId:
+        description: Optional subscription ID (max length 64).
+        maxLength: 64
+        type: string
+    required:
+    - contactId
+    type: object
+
+  loyaltyProgramPage:
+    type: object
+    properties:
+      items:
+        type: array
+        description: Loyalty Program list
+        items:
+          $ref: '#/definitions/loyaltyProgram'
+  loyaltyProgram:
+    type: object
+    properties:
+      codeCount:
+        description:  Loyalty Program code count
+        type: integer
+      createdAt:
+        description: Loyalty Program creation date
+        type: string
+      description:
+        description: Loyalty Program description
+        type: string
+      documentId:
+        description: string
+        type: string
+      id:
+        description: Loyalty Program ID
+        type: string
+      meta:
+        additionalProperties: {}
+        description: Loyalty Program meta data
+        type: object
+      name:
+        description: Loyalty Program name
+        type: string
+      pattern:
+        description: string
+        type: string
+      state:
+        description: Loyalty Program state
+        type: string
+        enum:
+        - inactive
+        - active
+      subscriptionGeneratorId:
+        description: Loyalty Program subscription generator ID
+        type: string
+      subscriptionPoolId:
+        description: Loyalty Program subscription pool ID
+        type: string
+      updatedAt:
+        description: Loyalty Program last modification date
+        type: string
+  createSubscriptionResponse:
+    type: object
+    properties:
+      organizationId:
+        description: Organization ID
+        type: integer
+      loyaltyProgramId:
+        description: Loyalty Program ID
+        type: string
+        format: uuid
+      versionId:
+        description: Version ID
+        type: integer
+      contactId:
+        description: Contact ID
+        type: integer
+      loyaltySubscriptionId:
+        description: Loyalty Subscription ID
+        type: string
+      createdAt:
+        description: Subscription creation date
+        type: string
+        format: date-time
+      updatedAt:
+        description: Subscription last modification date
+        type: string
+        format: date-time
+  updateLoyaltyProgramPayload:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Loyalty Program name
+      description:
+        type: string
+        description: Loyalty Program description
+      meta:
+        type: object
+        description: Loyalty Program meta data
+    required:
+      - name
+
+  validationErrors:
+    type: array
+    items:
+      $ref: '#/definitions/loyaltyProgramValidationError'
+
+  loyaltyProgramValidationError:
+    type: object
+    properties:
+      path:
+        type: string
+        description: Path of data that failed validation
+      rule:
+        type: string
+        description: Rule that failed validation
+      error:
+        type: string
+        description: Validation error message
+
+  patchLoyaltyProgramPayload:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Loyalty Program name
+      description:
+        type: string
+        description: Loyalty Program description
+      meta:
+        type: object
+        description: Loyalty Program meta data
+  # offer service schema
+  main.attributeRewardPayload:
+    properties:
+      value:
+        description: Value of the selected reward config
+        format: float64
+        type: number
+      code:
+        description: Code generated to attribute reward to a contact
+        maxLength: 128
+        type: string
+      contactId:
+        description: Contact to attribute the reward
+        format: int64
+        minimum: 1
+        type: integer
+      expirationDate:
+        description: Reward expiration date
+        type: string
+      loyaltySubscriptionId:
+        description: One of contactId or loyaltySubscriptionId is required
+        type: string
+      meta:
+        additionalProperties: {}
+        description: Offer meta information (key/value object)
+        type: object
+      rewardId:
+        description: Reward id
+        type: string
+        format: uuid
+    required:
+      - rewardId
+    type: object
+  main.billingPayload:
+    properties:
+      address:
+        description: Address of the user
+        type: string
+      city:
+        description: City of the user
+        type: string
+      countryCode:
+        description: Country code of the user
+        type: string
+      paymentMethod:
+        description: Payment method opted by the user
+        type: string
+      phone:
+        description: Phone number of the user
+        type: integer
+        format: int64
+      postCode:
+        description: Postal Code of user's locations
+        type: integer
+        format: int64
+      region:
+        description: Region where user resides
+        type: string
+    type: object
+  main.codeCountHttpResponse:
+    properties:
+      count:
+        description: Number of codes
+        format: int64
+        type: integer
+    type: object
+  main.createRedeemPayload:
+    properties:
+      attributedRewardId:
+        description: Unique identifier for the attributed reward
+        type: string
+        format: uuid
+      code:
+        description: Redemption code for the reward
+        type: string
+      contactId:
+        description: Unique identifier for the contact
+        minimum: 1
+        type: integer
+        format: int64
+      loyaltySubscriptionId:
+        description: Identifier for the loyalty subscription
+        type: string
+      meta:
+        additionalProperties: {}
+        description: Additional metadata associated with the redeem request
+        type: object
+      order:
+        allOf:
+        - $ref: '#/definitions/main.orderPayload'
+        description: Order details for the redemption
+      rewardId:
+        description: Unique identifier for the reward
+        type: string
+        format: uuid
+      ttl:
+        description: Time to live in seconds for the redemption request
+        minimum: 0
+        type: integer
+    type: object
+  main.createRewardPayload:
+    properties:
+      name:
+        description: Internal name of the reward
+        maxLength: 128
+        type: string
+      publicDescription:
+        description: Public facing description of the reward
+        maxLength: 128
+        type: string
+      publicImage:
+        description: URL of the public image for the reward
+        type: string
+        format: uri
+      publicName:
+        description: Public facing name of the reward
+        maxLength: 128
+        type: string
+    required:
+      - name
+    type: object
+  main.errorResponse:
+    properties:
+      message:
+        type: string
+        description: Error message indicating what went wrong
+    type: object
+  main.filter:
+    properties:
+      metadata.key:
+        description: Metadata key
+        type: string
+      metadata.value:
+        description: Metadata value
+    required:
+      - metadata.key
+      - metadata.value
+    type: object
+  main.generator:
+    properties:
+      createdAt:
+        description: Timestamp when the reward was created
+        type: string
+      description:
+        description: Public facing description of the reward
+        type: string
+      id:
+        description: Unique identifier for the reward
+        format: uuid
+        type: string
+      name:
+        description: Name of the reward
+        type: string
+      pattern:
+        description: Generated pattern
+        type: string
+      updatedAt:
+        description: Timestamp when the reward was created
+        format: date-time
+        type: string
+    type: object
+  main.getContactRewardsPayload:
+    properties:
+      contactId:
+        description: Contact to attribute the reward
+        minimum: 1
+        type: integer
+      limit:
+        description: Number of documents per page
+        maximum: 500
+        minimum: 1
+        type: integer
+      metadata:
+        description: Data to define the reward for that particular contact
+        items:
+          $ref: '#/definitions/main.filter'
+        type: array
+      offset:
+        description: Index of the first document in the page
+        minimum: 0
+        type: integer
+      rewardId:
+        description: Unique identifier of the associated reward
+        type: string
+      sort:
+        description: Sort the documents in the ascending or descending order
+        enum:
+          - asc
+          - desc
+        type: string
+      sortField:
+        description: Sort documents by field
+        enum:
+          - updatedAt
+          - createdAt
+        type: string
+    required:
+      - contactId
+    type: object
+  main.identifiersPayload:
+    properties:
+      ext_id:
+        description: External identifier for the order
+        type: string
+      loyalty_subscription_id:
+        description: Identifier for the loyalty subscription
+        type: string
+    type: object
+  main.limit:
+    properties:
+      createdAt:
+        description: Timestamp when the reward limit was created
+        format: date-time
+        type: string
+      durationUnit:
+        description: Unit of time for the reward limit's availability (e.g., day/week/month/year).
+        type: string
+      durationValue:
+        description: Number of days/weeks/month/year for reward limit
+        type: integer
+      limitValue:
+        description: Value of the limit
+        type: integer
+      rewardLimitId:
+        description: Unique identifier for the reward limit
+        type: string
+      slidingSchedule:
+        description: Select true to calculate all redeems / attributions from previous value of selected durationUnit to current time
+        type: boolean
+      type:
+        description: Type of reward
+        type: string
+      updatedAt:
+        description: Timestamp when the reward limit was created
+        format: date-time
+        type: string
+    type: object
+  main.modelContactReward:
+    properties:
+      code:
+        description: Generated code
+        type: string
+      consumedAt:
+        description: Timestamp when the reward limit was consumed
+        type: string
+      createdAt:
+        description: Timestamp when the reward limit was created
+        type: string
+      expirationDate:
+        description: Reward expiration date
+        type: string
+      id:
+        description: Unique identifier for the contact
+        type: string
+      meta:
+        additionalProperties: {}
+        description: Additional data for the reward
+        type: object
+      rewardId:
+        description: Unique identifier for the reward
+        type: string
+      unit:
+        description: Unit of the balance selected in the reward definition
+        type: string
+      updatedAt:
+        description: Timestamp when the reward limit was updated
+        type: string
+      value:
+        description: Value of the selected reward config
+        format: float64
+        type: number
+    type: object
+  main.modelContactRewardsResp:
+    properties:
+      contactId:
+        description: Contact id associated with the current reward
+        format: int64
+        type: integer
+      contactRewards:
+        description: List of all the rewards for current contact
+        items:
+          $ref: '#/definitions/main.modelContactReward'
+        type: array
+      count:
+        description: Count of the rewards associated with the current contact
+        type: integer
+      loyaltyProgramId:
+        description: Loyalty Program Id for the contact
+        type: string
+      loyaltySubscriptionId:
+        description: Loyalty Subscription Id for the contact
+        type: string
+    type: object
+  main.nodeResponse:
+    properties:
+      args:
+        description: array[object]
+        items:
+          $ref: '#/definitions/main.nodeResponse'
+        type: array
+      array:
+        description: Array values for rule definition
+        items:
+          $ref: '#/definitions/main.nodeResponse'
+        type: array
+      boolean:
+        description: Boolean values for rule definition
+        type: boolean
+      description:
+        description: Description for rule definition
+        type: string
+      float:
+        description: Float values for rule definition
+        format: float64
+        type: number
+      int:
+        description: int64
+        format: int64
+        type: integer
+      op:
+        description: Operator selected for rule definition
+        type: string
+      string:
+        description: Boolean values for rule definition
+        type: string
+    type: object
+  main.orderPayload:
+    properties:
+      amount:
+        description: Total amount of the order
+        type: number
+        format: float64
+      billing:
+        allOf:
+        - $ref: '#/definitions/main.billingPayload'
+        description: Billing information for the order
+      contact_id:
+        description: Unique identifier for the contact
+        type: integer
+        format: int64
+      coupons:
+        description: List of coupon codes applied to the order
+        items:
+          type: string
+        type: array
+      createdAt:
+        description: Timestamp when the order was created
+        type: string
+        format: date-time
+      email:
+        description: Email address associated with the order
+        type: string
+        format: email
+      id:
+        description: Unique identifier for the order
+        type: string
+      identifiers:
+        allOf:
+        - $ref: '#/definitions/main.identifiersPayload'
+        description: Additional identifiers for the order
+      products:
+        description: List of products in the order
+        items:
+          $ref: '#/definitions/main.productPayload'
+        type: array
+      status:
+        description: Current status of the order
+        type: string
+      storeId:
+        description: Identifier for the store where the order was placed
+        type: string
+      updatedAt:
+        description: Timestamp when the order was last updated
+        type: string
+        format: date-time
+    type: object
+  main.product:
+    properties:
+      createdAt:
+        description: Timestamp when the product was created
+        type: string
+      imageRef:
+        description: URL of the product image
+        type: string
+      productId:
+        description: Unique identifier for the product
+        type: string
+      value:
+        description: string
+        type: string
+    type: object
+  main.productPayload:
+    properties:
+      category:
+        description: List of categories the product belongs to
+        items:
+          type: string
+        type: array
+      price:
+        description: Price of the product
+        type: number
+        format: float64
+      productId:
+        description: Unique identifier for the product
+        type: string
+      quantity:
+        description: Quantity of the product
+        type: number
+        format: float64
+      variantId:
+        description: Identifier for the product variant
+        type: string
+    type: object
+
+  main.redeem:
+    properties:
+      cancelledAt:
+        description: Timestamp when the redemption was cancelled
+        type: string
+        format: date-time
+      completedAt:
+        description: Timestamp when the redemption was completed
+        type: string
+        format: date-time
+      contactId:
+        description: Unique identifier for the contact
+        type: integer
+        format: int64
+      createdAt:
+        description: Timestamp when the redemption was created
+        type: string
+        format: date-time
+      debitTransactionId:
+        description: Unique identifier for the debit transaction
+        type: string
+        format: uuid
+      expiresAt:
+        description: Timestamp when the redemption expires
+        type: string
+        format: date-time
+      id:
+        description: Unique identifier for the redemption
+        type: string
+        format: uuid
+      loyaltyProgramId:
+        description: Unique identifier for the loyalty program
+        type: string
+        format: uuid
+      meta:
+        additionalProperties: {}
+        description: Additional metadata associated with the redemption
+        type: object
+      rejectReason:
+        description: Reason for rejection if the redemption was rejected
+        type: string
+      rejectedAt:
+        description: Timestamp when the redemption was rejected
+        type: string
+        format: date-time
+      rewardAttributionId:
+        description: Unique identifier for the reward attribution
+        type: string
+        format: uuid
+      status:
+        description: Current status of the redemption
+        type: string
+      updatedAt:
+        description: Timestamp when the redemption was last updated
+        type: string
+        format: date-time
+    type: object
+  main.resultParameterResponse:
+    properties:
+      name:
+        description: Name of the rule
+        type: string
+      value:
+        allOf:
+        - $ref: '#/definitions/main.valueResponse'
+        description: Selected value of the parameter to define the rule
+    type: object
+  main.reward:
+    properties:
+      attributionPerConsumer:
+        description: Maximum number of times a consumer can be attributed this reward
+        type: integer
+      balanceDefinitionId:
+        description: Unique identifier for the balance definition
+        format: uuid
+        type: string
+      code:
+        description: Unique code for the reward
+        type: string
+      codeCount:
+        description: Total number of codes generated
+        format: int64
+        type: integer
+      codeGeneratorId:
+        description: Unique identifier for the code generator
+        format: uuid
+        type: string
+      codePoolId:
+        description: Unique identifier for the code pool
+        format: uuid
+        type: string
+      config:
+        description: Configuration settings for the reward
+        type: string
+      createdAt:
+        description: Timestamp when the reward was created
+        format: date-time
+        type: string
+      disabledAt:
+        description: Disabled date of the reward
+        format: date-time
+        type: string
+      endDate:
+        description: End date of the reward validity
+        format: date-time
+        type: string
+      expirationDate:
+        description: Expiration date of the reward
+        format: date-time
+        type: string
+      expirationModifier:
+        description: Select startOfPeriod to configure rewards expiry on start of day/week/month/year. Select endOfPeriod to configure reward expiry on end of day/week/month/year, else select noModification
+        type: string
+        default: noModification
+        enum:
+          - startOfPeriod
+          - endOfPeriod
+          - noModification
+      expirationUnit:
+        description: Unit of time for the rewards's availability (e.g., day/week/month/year).
+        type: string
+      expirationValue:
+        description: Number of days/weeks/month/year for reward expiry
+        type: integer
+      generator:
+        allOf:
+        - $ref: '#/definitions/main.generator'
+        description: object
+      id:
+        description: Unique identifier for the reward
+        format: uuid
+        type: string
+      limits:
+        description: Attribution / Redeem Limits for the reward
+        items:
+          $ref: '#/definitions/main.limit'
+        type: array
+      loyaltyProgramId:
+        description: Id of the loyalty program to which the current reward belongs to
+        format: uuid
+        type: string
+      meta:
+        additionalProperties: {}
+        description: Additional data for reward definition
+        type: object
+      name:
+        description: Name of the reward
+        type: string
+      products:
+        description: Selected products for reward definition
+        items:
+          $ref: '#/definitions/main.product'
+        type: array
+      publicDescription:
+        description: Public description for the reward
+        type: string
+      publicImage:
+        description: Public Image for the reward
+        type: string
+      publicName:
+        description: Public name for the reward
+        type: string
+      redeemPerConsumer:
+        description: Defines the redeem limit for the consumer
+        type: integer
+      redeemRules:
+        description: Rules defined to redeem a reward
+        items:
+          type: string
+        type: array
+      rewardConfigs:
+        allOf:
+        - $ref: '#/definitions/main.rewardConfigurations'
+        description: object
+      rule:
+        allOf:
+        - $ref: '#/definitions/main.rule'
+        description: Rule to define the reward
+      startDate:
+        description: Start date of attribution of the reward
+        format: date-time
+        type: string
+      subtractBalanceDefinitionId:
+        description: Id of the selected balance while redeeming / attributing a reward
+        type: string
+      subtractBalanceStrategy:
+        description: Strategy of the Balance while redeeming / attributing a reward
+        type: string
+      subtractBalanceValue:
+        description: Amount of balance to be selected while redeeming / attributing a reward
+        type: integer
+      subtractTotalBalance:
+        description: Value to indicate to subtract full balance or not
+        type: boolean
+      totalAttribution:
+        description: Defines the limit to which a consumer can attribute a reward
+        type: integer
+      totalRedeem:
+        description: Defines the limit to which a consumer can redeem a reward
+        type: integer
+      triggerId:
+        description: Id of the Rule to be updated for that reward
+        type: string
+      unit:
+        description: Selected unit of the balance
+        type: string
+      updatedAt:
+        description: Timestamp for when this reward was last updated.
+        type: string
+      value:
+        description: Value of metric in selected config for reward definition
+        format: float64
+        type: number
+      valueType:
+        description: Type of config selected for reward definition
+        type: string
+    type: object
+
+  main.createRewardResponse:
+    properties:
+      createdAt:
+        description: Timestamp when the reward was created
+        format: date-time
+        type: string
+      id:
+        description: Unique identifier for the reward
+        format: uuid
+        type: string
+      loyaltyProgramId:
+        description: Id of the loyalty program to which the current reward belongs to
+        format: uuid
+        type: string
+      name:
+        description: Name of the reward
+        type: string
+      publicDescription:
+        description: Public description for the reward
+        type: string
+      publicImage:
+        description: Public Image for the reward
+        type: string
+      publicName:
+        description: Public name for the reward
+        type: string
+      updatedAt:
+        description: Timestamp for when this reward was last updated.
+        type: string
+    type: object
+
+  main.rewardAttribution:
+    properties:
+      value:
+        description: Value of the selected reward config
+        format: float64
+        type: number
+      code:
+        description: Generated code
+        type: string
+      consumedAt:
+        description: Timestamp for when this reward was consumed
+        type: string
+      contactId:
+        description: Id of the contact that attributed the reward
+        format: int64
+        type: integer
+      createdAt:
+        description: Timestamp for when this reward was created
+        format: date-time
+        type: string
+      expirationDate:
+        description: Expiration date of the reward
+        format: date-time
+        type: string
+      id:
+        description: Unique idenitifier
+        format: uuid
+        type: string
+      loyaltyProgramId:
+        description: Loyalty Program Id to which attributed reward belongs
+        type: string
+      meta:
+        additionalProperties: {}
+        description: Additional data to define the reward
+        type: object
+      rewardId:
+        description: Unique identifier for the reward
+        type: string
+      updatedAt:
+        description: Timestamp for when this reward was updated
+        format: date-time
+        type: string
+    type: object
+  main.rewardConfigurations:
+    properties:
+      attribution:
+        description: Attribution config of the reward
+        type: string
+      code:
+        description: Code config of the reward
+        type: string
+      value:
+        description: Value config of the reward
+        type: string
+    type: object
+  main.rewardPage:
+    properties:
+      items:
+        description: Items for the current reward
+        items:
+          $ref: '#/definitions/main.rewardPageObj'
+        type: array
+      totalCount:
+        description: Count of the associated parameter in current reward
+        type: integer
+    type: object
+  main.rewardPageObj:
+    properties:
+      createdAt:
+        description: Timestamp for when this reward was created
+        format: date-time
+        type: string
+      endDate:
+        description: Timestamp for when this reward attributed was ended
+        format: date-time
+        type: string
+      id:
+        description: Unique identifier for the reward
+        format: uuid
+        type: string
+      loyaltyProgramId:
+        description: Loyalty Program to which current reward is associated to
+        format: uuid
+        type: string
+      name:
+        description: Name of the reward
+        type: string
+      publicImage:
+        description: Public image of the reward
+        type: string
+      startDate:
+        description: Timestamp for when this reward attributed was started
+        type: string
+        format: date-time
+      state:
+        description: State of the reward
+        type: string
+      updatedAt:
+        description: Timestamp for when this reward attributed was updated
+        type: string
+        format: date-time
+    type: object
+  main.rewardValidate:
+    properties:
+      authorize:
+        description: Boolean Value to authorize a reward or not
+        type: boolean
+    type: object
+  main.rule:
+    properties:
+      condition:
+        allOf:
+        - $ref: '#/definitions/main.ruleConditionResponse'
+        description: Selected rule condition
+      createdAt:
+        description: Timestamp when the rule was created
+        type: string
+      description:
+        description: Description of the rule
+        type: string
+      event:
+        allOf:
+        - $ref: '#/definitions/main.ruleEventResponse'
+        description: Selected event in the rule
+      isInternal:
+        description: Metric to identify if its an internal rule or not
+        type: boolean
+      loyaltyProgramId:
+        description: Loyalty Program id of which current rule is associated
+        type: string
+      loyaltyVersionId:
+        description: Loyalty Version id to which current rule is associated
+        format: int16
+        type: integer
+      meta:
+        additionalProperties: true
+        description: Additional data to define the rule
+        type: object
+      name:
+        description: Rule name
+        type: string
+      results:
+        description: Results fo the rule definition
+        items:
+          $ref: '#/definitions/main.ruleResultResponse'
+        type: array
+      ruleId:
+        description: Unique identifier for the rule
+        type: string
+      ruleType:
+        description: Type of the rule
+        type: string
+      updatedAt:
+        description: Timestamp when the rule was updated
+        type: string
+    type: object
+  main.ruleConditionResponse:
+    properties:
+      and:
+        description: Metric to indicate AND between rules
+        items:
+          $ref: '#/definitions/main.ruleConditionResponse'
+        type: array
+      lhs:
+        allOf:
+        - $ref: '#/definitions/main.valueResponse'
+        description: Conditon of the rule
+      op:
+        description: Selected operator for the rule
+        type: string
+      or:
+        description: Metric to indicate OR between rules
+        items:
+          $ref: '#/definitions/main.ruleConditionResponse'
+        type: array
+      rhs:
+        allOf:
+        - $ref: '#/definitions/main.valueResponse'
+        description: Action of the rule
+    type: object
+  main.ruleEventResponse:
+    properties:
+      name:
+        description: Name of the event
+        type: string
+      source:
+        description: Source of the event
+        type: string
+    type: object
+  main.ruleResultResponse:
+    properties:
+      action:
+        description: Action for the defined rule
+        type: string
+      parameters:
+        description: Parameters to define the reward
+        items:
+          $ref: '#/definitions/main.resultParameterResponse'
+        type: array
+      service:
+        description: Selected service to define the reward
+        type: string
+    type: object
+  main.validateRewardPayload:
+    properties:
+      attributedRewardId:
+        description: Unique identifier for the attributed reward
+        type: string
+        format: uuid
+      code:
+        description: Validation code for the reward
+        type: string
+      contactId:
+        description: Unique identifier for the contact
+        minimum: 1
+        type: integer
+        format: int64
+      loyaltySubscriptionId:
+        description: Identifier for the loyalty subscription
+        type: string
+      pointOfSellId:
+        description: Identifier for the point of sale
+        type: string
+      rewardId:
+        description: Unique identifier for the reward
+        type: string
+        format: uuid
+    type: object
+  main.valueResponse:
+    properties:
+      array:
+        description: Array values to define the rule
+        items:
+          $ref: '#/definitions/main.valueResponse'
+        type: array
+      boolean:
+        description: Boolean values for rule definition
+        type: boolean
+      contactProperty:
+        description: string
+        type: string
+      date:
+        description: Selected date for rule definition
+        type: string
+      eventProperty:
+        description: Selected event property for rule definition
+        type: string
+      expression:
+        allOf:
+        - $ref: '#/definitions/main.nodeResponse'
+        description: Created expression for rule definition
+      number:
+        description: Boolean values for rule definition
+        format: float64
+        type: number
+      string:
+        description: String values for rule definition
+        type: string
+    type: object
+  main.voucherRevokePayload:
+    properties:
+      attributedRewardIds:
+        description: List of attributed reward identifiers to be revoked
+        items:
+          type: string
+          format: uuid
+        type: array
+    required:
+      - attributedRewardIds
+    type: object
+
+  aggregateBalance:
+    properties:
+      balanceDefinitionId:
+        description: balance definition ID
+        type: string
+      value:
+        description: Unique identifier for the balance definition associated with this aggregate balance
+        type: number
+    type: object
+  balance:
+    properties:
+      amount:
+        description: The current amount available in the balance
+        type: number
+      balanceDefinitionId:
+        description: balance definition ID
+        type: string
+      consumedAt:
+        description: Timestamp of when the balance was last consumed
+        type: string
+      contactId:
+        description: contact ID
+        type: integer
+      createdAt:
+        description: Timestamp of when the balance was created
+        type: string
+      expiresAt:
+        description: Expiration timestamp of the balance
+        type: string
+      id:
+        description: Unique identifier for the balance
+        type: string
+      loyaltyProgramId:
+        description: loyalty program ID
+        type: string
+      organizationId:
+        description: organization ID
+        type: integer
+    type: object
+  balanceDataPerContact:
+    properties:
+      contactId:
+        type: integer
+      loyaltySubscriptionId:
+        type: string
+      updatedAt:
+        type: string
+      value:
+        type: number
+    type: object
+  balanceDefinition:
+    properties:
+      balanceAvailabilityDurationModifier:
+        type: string
+        enum: [startOfPeriod, endOfPeriod, noModification]
+        description: startOfPeriod depicts the balancy expiry on start of day/week/month/year. endOfPeriod depicts the balancy expiry on end of day/week/month/year
+      balanceAvailabilityDurationUnit:
+        description: Unit of time for the balance's availability (e.g., day/week/month/year).
+        type: string
+      balanceAvailabilityDurationValue:
+        description: Number of days/weeks/month/year for balance expiry
+        type: integer
+      balanceExpirationDate:
+        type: string
+        format: date-time
+        description: Date when the balance expires and can no longer be used, in dd/mm format. The balance will be expired when this date appears next in the calendar and only one of balanceExpirationDate or balance availability fields can be used.
+      balanceOptionAmountOvertakingStrategy:
+        description: Partial enables partial credit of balance if maximum balance limit is reaching. Strict enables rejection of transaction if it will breach the max credit amount limit.
+        type: string
+      balanceOptionCreditRounding:
+        description: Rounding strategy for credit transactions.
+        type: string
+      balanceOptionDebitRounding:
+        description: Rounding strategy for debit transactions.
+        type: string
+      createdAt:
+        type: string
+        format: date-time
+        description: Timestamp of balance definition creation.
+      deletedAt:
+        description: Timestamp of balance definition deletion (nullable).
+        type: string
+      description:
+        description: Short description of the balance definition.
+        type: string
+      id:
+        description: Unique identifier for the balance definition.
+        type: string
+      imageRef:
+        description: Optional image reference URL.
+        type: string
+      maxAmount:
+        description: Maximum allowable balance.
+        type: number
+      maxCreditAmountLimit:
+        description: Max credit allowed per operation.
+        type: number
+      maxDebitAmountLimit:
+        description: Max debit allowed per operation.
+        type: number
+      meta:
+        additionalProperties: {}
+        description: Additional metadata for the balance definition.
+        type: object
+      minAmount:
+        description: Minimum allowable balance.
+        type: number
+      name:
+        description: Name of the balance definition.
+        type: string
+      unit:
+        description: Unit of balance (e.g., points, currency).
+        type: string
+      updatedAt:
+        description: Timestamp of the last update.
+        type: string
+    type: object
+  balanceDefinitionPage:
+    properties:
+      items:
+        description: list of balance definitions
+        items:
+          $ref: '#/definitions/balanceDefinition'
+        type: array
+    type: object
+  balanceLimit:
+    properties:
+      balanceDefinitionId:
+        description: balance definition ID
+        type: string
+      constraintType:
+        description: Defines the type of constraint (e.g., transaction-based or amount-based).
+        type: string
+      createdAt:
+        description: Timestamp of when the balance limit was created.
+        type: string
+      durationUnit:
+        description: Time unit for the balance limit (day, week, month, year).
+        type: string
+      durationValue:
+        description: Number of time units the balance limit applies to.
+        type: integer
+      id:
+        description: Unique identifier for the balance limit.
+        type: string
+      slidingSchedule:
+        description: Indicates if the limit resets periodically based on a sliding schedule.
+        type: boolean
+      transactionType:
+        description: Specifies whether the limit applies to credit or debit transactions.
+        type: string
+      updatedAt:
+        description: Timestamp of the last update to the balance limit.
+        type: string
+      value:
+        description: The maximum allowed value for the defined constraint.
+        type: integer
+    required:
+    - createdAt
+    - updatedAt
+    type: object
+  contactBalancesResp:
+    properties:
+      balanceDefinitionId:
+        type: string
+      balances:
+        items:
+          $ref: '#/definitions/balanceDataPerContact'
+        type: array
+      count:
+        type: integer
+      loyaltyProgramId:
+        type: string
+    type: object
+  createBalanceDefinitionPayload:
+    description: Payload for creating a new balance definition, specifying expiration rules, rounding strategies, and constraints.
+    type: object
+    properties:
+      balanceAvailabilityDurationModifier:
+        type: string
+        enum: [noModification, startOfPeriod, endOfPeriod]
+        description: Defines when the balance expires within the selected duration.
+      balanceAvailabilityDurationUnit:
+        type: string
+        enum: [day, week, month, year]
+        description: Unit of time for balance validity.
+      balanceAvailabilityDurationValue:
+        type: integer
+        description: Number of time units before the balance expires.
+      balanceExpirationDate:
+        type: string
+        format: date
+        description: Fixed expiration date (`dd/mm` format) as an alternative to duration-based expiry.
+      balanceOptionAmountOvertakingStrategy:
+        type: string
+        enum: [strict, partial]
+        description: Defines whether partial credit is allowed when reaching max balance.
+      balanceOptionCreditRounding:
+        type: string
+        enum: [lower, upper, natural]
+        description: Defines rounding strategy for credit transactions.
+      balanceOptionDebitRounding:
+        type: string
+        enum: [lower, upper, natural]
+        description: Defines rounding strategy for debit transactions.
+      description:
+        type: string
+        maxLength: 256
+        description: Short description of the balance definition.
+      imageRef:
+        type: string
+        description: URL of an optional image reference.
+      maxAmount:
+        type: number
+        description: Maximum allowable balance amount.
+      maxCreditAmountLimit:
+        type: number
+        description: Maximum credit allowed per operation.
+      maxDebitAmountLimit:
+        type: number
+        description: Maximum debit allowed per operation.
+      meta:
+        additionalProperties: true
+        type: object
+        description: Additional metadata for the balance definition.
+        example:
+          isInternal: true
+        properties:
+          isInternal:
+            description: Indicates whether the balance definition is internal.
+            type: boolean
+      minAmount:
+        type: number
+        description: Minimum allowable balance amount.
+      name:
+        type: string
+        maxLength: 128
+        description: Name of the balance definition.
+      unit:
+        type: string
+        enum: [POINTS, EUR, USD, MXN, GBP, INR, CAD, SGD, RON, JPY, MYR, CLP, PEN, MAD, AUD, CHF, BRL]
+        description: Unit of balance measurement.
+    required:
+      - name
+      - unit
+
+  createBalanceLimitPayload:
+    description: Payload for setting transaction or amount-based limits on a balance.
+    type: object
+    properties:
+      constraintType:
+        type: string
+        enum: [transaction, amount]
+        description: Defines whether the limit applies to transaction count or amount.
+      durationUnit:
+        type: string
+        enum: [day, week, month, year]
+        description: Unit of time for which the limit is applicable.
+      durationValue:
+        type: integer
+        description: Number of time units for the balance limit.
+      slidingSchedule:
+        type: boolean
+        description: Determines if the limit resets on a rolling schedule.
+      transactionType:
+        type: string
+        enum: [credit, debit]
+        description: Specifies whether the limit applies to credit or debit transactions.
+      value:
+        type: integer
+        description: Maximum allowed value for the specified constraint type.
+    required:
+      - constraintType
+      - durationUnit
+      - durationValue
+      - transactionType
+      - value
+
+  createBalancePayload:
+    description: Payload for creating a new balance linked to a specific balance definition.
+    type: object
+    properties:
+      balanceDefinitionId:
+        type: string
+        description: Unique identifier (UUID) of the balance definition associated with the new balance.
+    required:
+      - balanceDefinitionId
+  createOrderPayload:
+    description: Payload for creating an order linked to a balance definition.
+    type: object
+    properties:
+      amount:
+        type: number
+        description: Order amount (must be non-zero).
+      balanceDefinitionId:
+        type: string
+        description: Unique identifier (UUID) of the associated balance definition.
+      contactId:
+        type: integer
+        minimum: 1
+        description: Unique identifier of the contact placing the order (must be ≥ 1).
+      dueAt:
+        type: string
+        description: RFC3339 timestamp specifying when the order is due.
+      expiresAt:
+        type: string
+        description: Optional RFC3339 timestamp defining order expiration.
+      meta:
+        type: object
+        additionalProperties: true
+        description: Optional metadata associated with the order.
+      source:
+        type: string
+        description: Specifies the origin of the order (`engine` or `user`).
+    required:
+      - amount
+      - balanceDefinitionId
+      - contactId
+      - dueAt
+      - source
+
+  createTransactionPayload:
+    description: Payload for creating a transaction, specifying balance details and optional expiration.
+    type: object
+    properties:
+      LoyaltySubscriptionId:
+        type: string
+        description: Unique identifier for the loyalty subscription (required unless `contactId` is provided).
+      amount:
+        type: number
+        description: Transaction amount (must be provided).
+      autoComplete:
+        type: boolean
+        description: Whether the transaction should be automatically completed.
+      balanceDefinitionId:
+        type: string
+        description: Unique identifier (UUID) of the associated balance definition.
+      balanceExpiryInMinutes:
+        type: integer
+        description: Optional expiry time for the balance in minutes (must be greater than 0 if provided).
+      contactId:
+        type: integer
+        minimum: 1
+        description: Unique identifier of the contact involved in the transaction (required unless `LoyaltySubscriptionId` is provided).
+      eventTime:
+        type: string
+        description: Optional timestamp specifying when the transaction occurred.
+      meta:
+        type: object
+        additionalProperties: true
+        description: Optional metadata associated with the transaction.
+      ttl:
+        type: integer
+        description: Optional time-to-live for the transaction (must be greater than 0 if provided).
+    required:
+      - amount
+      - balanceDefinitionId
+
+  modelSubscriptionBalanceResp:
+    properties:
+      balance:
+        items:
+          $ref: '#/definitions/aggregateBalance'
+        type: array
+    type: object
+  balanceOrder:
+    description: Represents an order linked to a balance definition, including amount, due date, and transaction details.
+    type: object
+    properties:
+      amount:
+        type: number
+        description: Order amount (must not be zero).
+      balanceDefinitionId:
+        type: string
+        description: Optional unique identifier (UUID) of the associated balance definition.
+      contactId:
+        type: integer
+        minimum: 1
+        description: Unique identifier of the contact placing the order (must be ≥ 1).
+      createdAt:
+        type: string
+        description: RFC3339 timestamp indicating when the order was created.
+      dueAt:
+        type: string
+        description: RFC3339 timestamp specifying when the order is due in the future.
+      expiresAt:
+        type: string
+        description: Optional RFC3339 timestamp defining order expiration in the future.
+      id:
+        type: string
+        description: Unique identifier for the balance order.
+      loyaltyProgramId:
+        type: string
+        description: Unique identifier of the loyalty program associated with the order.
+      meta:
+        type: object
+        additionalProperties: true
+        description: Optional metadata associated with the order.
+      processedAt:
+        type: string
+        description: Optional RFC3339 timestamp indicating when the order was processed.
+      transactionid:
+        type: string
+        description: Optional reference to the associated transaction ID.
+      updatedAt:
+        type: string
+        description: RFC3339 timestamp indicating the last update to the order.
+    required:
+      - amount
+      - contactId
+      - createdAt
+      - dueAt
+      - loyaltyProgramId
+      - updatedAt
+
+  transaction:
+    description: Represents a transaction involving a balance, including status and timestamps.
+    type: object
+    properties:
+      amount:
+        type: number
+        description: The transaction amount.
+      balanceDefinitionId:
+        type: string
+        description: Unique identifier (UUID) of the associated balance definition.
+      cancelledAt:
+        type: string
+        description: Timestamp when the transaction was canceled (nullable).
+      completedAt:
+        type: string
+        description: Timestamp when the transaction was completed (nullable).
+      contactId:
+        type: integer
+        description: Unique identifier of the contact associated with the transaction.
+      createdAt:
+        type: string
+        description: Timestamp when the transaction was created.
+      eventTime:
+        type: string
+        description: Optional timestamp indicating when the transaction event occurred.
+      expirationDate:
+        type: string
+        description: Expiry date of the transaction (nullable).
+      id:
+        type: string
+        description: Unique identifier (UUID) of the transaction.
+      loyaltyProgramId:
+        type: string
+        description: Unique identifier (UUID) of the associated loyalty program.
+      meta:
+        type: object
+        additionalProperties: true
+        description: Optional metadata associated with the transaction.
+      rejectReason:
+        type: string
+        description: Reason for rejection if the transaction was declined (nullable).
+      rejectedAt:
+        type: string
+        description: Timestamp when the transaction was rejected (nullable).
+      status:
+        type: string
+        description: The current status of the transaction (e.g., pending, completed, rejected).
+      updatedAt:
+        type: string
+        description: Timestamp when the transaction was last updated.
+
+  transactionHistory:
+    description: Represents a record of a past transaction, including status and key timestamps.
+    type: object
+    properties:
+      amount:
+        type: number
+        description: The transaction amount.
+      balanceExpirationDate:
+        type: string
+        description: Expiration date of the balance associated with this transaction.
+      cancelledAt:
+        type: string
+        description: Timestamp when the transaction was canceled, if applicable.
+      completedAt:
+        type: string
+        description: Timestamp when the transaction was successfully completed.
+      createdAt:
+        type: string
+        description: Timestamp when the transaction was initiated.
+      id:
+        type: string
+        description: Unique identifier of the transaction.
+      meta:
+        type: object
+        additionalProperties: true
+        description: Optional metadata associated with the transaction.
+      rejectReason:
+        type: string
+        description: Reason for rejection, if the transaction was declined.
+      rejectedAt:
+        type: string
+        description: Timestamp when the transaction was rejected.
+      status:
+        type: string
+        description: Current status of the transaction (e.g., pending, completed, rejected).
+
+  transactionHistoryResp:
+    description: Response containing transaction history details for a specific balance and contact.
+    type: object
+    properties:
+      balanceDefinitionId:
+        type: string
+        description: Unique identifier of the associated balance definition.
+      contactId:
+        type: integer
+        description: Unique identifier of the contact related to the transactions.
+      count:
+        type: integer
+        description: Total number of transactions in the history.
+      loyaltyProgramId:
+        type: string
+        description: Unique identifier of the associated loyalty program.
+      transactionHistory:
+        type: array
+        items:
+          $ref: '#/definitions/transactionHistory'
+        description: List of past transactions associated with the balance.
+
+  updateBalanceDefinitionPayload:
+    description: Payload for updating an existing balance definition, including expiry rules, rounding strategies, and constraints.
+    type: object
+    properties:
+      balanceAvailabilityDurationModifier:
+        type: string
+        enum: [noModification, startOfPeriod, endOfPeriod]
+        description: Defines when the balance expires within the selected duration.
+      balanceAvailabilityDurationUnit:
+        type: string
+        enum: [day, week, month, year]
+        description: Unit of time for balance validity.
+      balanceAvailabilityDurationValue:
+        type: integer
+        description: Number of time units before the balance expires.
+      balanceExpirationDate:
+        type: string
+        description: Expiration date (`dd/mm` format) or empty if not applicable.
+      balanceOptionAmountOvertakingStrategy:
+        type: string
+        enum: [strict, partial]
+        description: Defines whether partial credit is allowed when reaching max balance.
+      balanceOptionCreditRounding:
+        type: string
+        enum: [lower, upper, natural]
+        description: Rounding strategy for credit transactions.
+      balanceOptionDebitRounding:
+        type: string
+        enum: [lower, upper, natural]
+        description: Rounding strategy for debit transactions.
+      description:
+        type: string
+        maxLength: 256
+        description: Short description of the balance definition.
+      imageRef:
+        type: string
+        description: URL of an optional image reference.
+      maxAmount:
+        type: number
+        description: Maximum allowable balance amount.
+      maxCreditAmountLimit:
+        type: number
+        description: Maximum credit allowed per operation.
+      maxDebitAmountLimit:
+        type: number
+        description: Maximum debit allowed per operation.
+      meta:
+        type: object
+        additionalProperties: true
+        description: Optional metadata for the balance definition.
+        example:
+          isInternal: true
+        properties:
+          isInternal:
+            description: Indicates whether the balance definition is internal.
+            type: boolean
+      minAmount:
+        type: number
+        description: Minimum allowable balance amount.
+      name:
+        type: string
+        maxLength: 128
+        description: Name of the balance definition.
+      unit:
+        type: string
+        enum: [POINTS, EUR, USD, MXN, GBP, INR, CAD, SGD, RON, JPY, MYR, CLP, PEN, MAD, AUD, CHF, BRL]
+        description: Unit of balance measurement.
+    required:
+      - name
+      - unit
+
+  updateBalanceLimitPayload:
+    description: Payload for updating an existing balance limit, specifying constraints on transactions or amounts.
+    type: object
+    properties:
+      constraintType:
+        type: string
+        enum: [transaction, amount]
+        description: Defines whether the limit applies to transaction count or amount.
+      durationUnit:
+        type: string
+        enum: [day, week, month, year]
+        description: Unit of time for which the limit is applicable.
+      durationValue:
+        type: integer
+        description: Number of time units for the balance limit.
+      slidingSchedule:
+        type: boolean
+        description: Determines if the limit resets on a rolling schedule.
+      transactionType:
+        type: string
+        enum: [credit, debit]
+        description: Specifies whether the limit applies to credit or debit transactions.
+      value:
+        type: integer
+        description: Maximum allowed value for the specified constraint type.
+    required:
+      - constraintType
+      - durationUnit
+      - durationValue
+      - transactionType
+      - value
+
+  # Tier
+  createTierGroupRequest:
+    required:
+      - name
+    type: object
+    properties:
+      name:
+        type: string
+        description: Name of the tier group
+      meta:
+        type: object
+        additionalProperties: true
+        description: Additional metadata for the tier group.
+        example:
+          isInternal: true
+        properties:
+          isInternal:
+            description: Indicates whether the tier group is internal.
+            type: boolean
+      upgradeStrategy:
+        type: string
+        description: Select real_time to upgrade tier on real time balance updates. Select membership_anniversary to upgrade tier on subscription anniversary. Select tier_anniversary to upgrade tier on tier anniversary.
+        enum:
+          - real_time
+          - membership_anniversary
+          - tier_anniversary
+        default: real_time
+      downgradeStrategy:
+        type: string
+        description: Select real_time to downgrade tier on real time balance updates. Select membership_anniversary to downgrade tier on subscription anniversary. Select tier_anniversary to downgrade tier on tier anniversary.
+        enum:
+          - real_time
+          - membership_anniversary
+          - tier_anniversary
+        default: real_time
+      tierOrder:
+        description: Order of the tiers in the group in ascending order
+        items:
+          type: string
+        type: array
+
+  updateTierGroupRequest:
+    required:
+      - downgradeStrategy
+      - name
+      - tierOrder
+      - upgradeStrategy
+    type: object
+    properties:
+      name:
+        type: string
+        description: Name of the tier group
+      meta:
+        type: object
+        additionalProperties: true
+        description: Additional metadata for the tier group.
+        example:
+          isInternal: true
+        properties:
+          isInternal:
+            description: Indicates whether the tier group is internal.
+            type: boolean
+
+      tierOrder:
+        type: array
+        items:
+          type: string
+          format: uuid
+        example: []
+        description: Order of the tiers in the group in ascending order
+
+      upgradeStrategy:
+        type: string
+        description: Select real_time to upgrade tier on real time balance updates. Select membership_anniversary to upgrade tier on subscription anniversary. Select tier_anniversary to upgrade tier on tier anniversary.
+        enum:
+          - real_time
+          - membership_anniversary
+          - tier_anniversary
+        default: real_time
+      downgradeStrategy:
+        type: string
+        description: Select real_time to downgrade tier on real time balance updates. Select membership_anniversary to downgrade tier on subscription anniversary. Select tier_anniversary to downgrade tier on tier anniversary.
+        enum:
+          - real_time
+          - membership_anniversary
+          - tier_anniversary
+        default: real_time
+
+
+  tierGroup:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        description: Tier group unique identifier
+      name:
+        type: string
+        description: Tier group name
+      tierOrder:
+        type: array
+        items:
+          type: string
+          format: uuid
+        example: []
+        description: Order of the tiers in the group in ascending order
+      loyaltyProgramId:
+        type: string
+        format: uuid
+        description: Associated loyalty program Id
+      upgradeStrategy:
+        type: string
+        description: Select real_time to upgrade tier on real time balance updates. Select membership_anniversary to upgrade tier on subscription anniversary. Select tier_anniversary to upgrade tier on tier anniversary.
+        enum:
+          - real_time
+          - membership_anniversary
+          - tier_anniversary
+        default: real_time
+
+      downgradeStrategy:
+        type: string
+        description: Select real_time to downgrade tier on real time balance updates. Select membership_anniversary to downgrade tier on subscription anniversary. Select tier_anniversary to downgrade tier on tier anniversary.
+        enum:
+          - real_time
+          - membership_anniversary
+          - tier_anniversary
+        default: real_time
+      createdAt:
+        type: string
+        format: date-time
+        description: Timestamp when the tier group was created
+      updatedAt:
+        type: string
+        format: date-time
+        description: Timestamp when the tier group was last updated
+
+  tierGroupPage:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          $ref: "#/definitions/tierGroup"
+
+  errorResponse:
+    properties:
+      message:
+        type: string
+    type: object
+
+  unauthorizedResponse:
+    type: object
+    properties:
+      error:
+        type: string
+        description: Request Authentication Failed
+
+  loyaltyTierPage:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/tier'
+
+  tier:
+    type: object
+    properties:
+      tierId:
+        type: string
+        format: uuid
+        description: Tier id
+      name:
+        type: string
+        description: Tier name
+      imageRef:
+        type: string
+        description: Tier image reference
+      loyaltyProgramId:
+        type: string
+        format: uuid
+        description: Associated loyalty program Id
+      groupId:
+        type: string
+        format: uuid
+        description: Associated group Id
+      createdAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
+      accessConditions:
+        type: array
+        description: Conditions required to access this tier
+        items:
+          type: object
+          properties:
+            balanceDefinitionId:
+              type: string
+              format: uuid
+              description: Balance definition identifier
+            minimumValue:
+              type: integer
+              description: Minimum value required to access this tier
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+      tierRewards:
+        type: array
+        description: Rewards associated with this tier
+        items:
+          type: object
+          properties:
+            rewardId:
+              type: string
+              format: uuid
+              description: Reward to be attributed on tier assignment
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+
+  tierRequest:
+    type: object
+    required:
+      - name
+      - accessConditions
+    properties:
+      name:
+        type: string
+        description: Name of the tier to be created
+      imageRef:
+        description: Image of the tier
+        type: string
+      accessConditions:
+        type: array
+        items:
+          type: object
+          properties:
+            balanceDefinitionId:
+              type: string
+              format: uuid
+              description: Balance definition identifier for accessing the tier
+            minimumValue:
+              type: integer
+              description: Minimum value required to access the tier
+      tierRewards:
+        type: array
+        items:
+          type: object
+          properties:
+            rewardId:
+              type: string
+              format: uuid
+              description: Reward unique identifier
+
+  tierRequestPutPayload:
+    type: object
+    required:
+      - name
+      - accessConditions
+      - tierRewards
+    properties:
+      name:
+        type: string
+        description: Name of the tier to be created
+      imageRef:
+        description: Image of the tier
+        type: string
+      accessConditions:
+        type: array
+        items:
+          type: object
+          properties:
+            balanceDefinitionId:
+              type: string
+              format: uuid
+              description: Balance definition identifier for accessing the tier
+            minimumValue:
+              type: integer
+              description: Minimum value required to access the tier
+      tierRewards:
+        type: array
+        items:
+          type: object
+          properties:
+            rewardId:
+              type: string
+              format: uuid
+              description: Reward unique identifier
+
+  tierForContact:
+    type: object
+    properties:
+      id:
+        type: string
+        format: uuid
+        description: Unique identifier for the assigned tier
+      loyaltyProgramId:
+        type: string
+        format: uuid
+        description: Associated loyalty program Id
+      groupId:
+        type: string
+        format: uuid
+        description: Group Id to which the tier is associated
+      contactId:
+        type: integer
+        description: Contact to which the tier is assigned
+      meta:
+        additionalProperties: {}
+        description: object
+        type: object
+      createdAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
+
+
+  createModel:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the object created
+        example: 122
+
+  createPaymentResponse:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: string
+        description: ID of the object created
+        example: 6d4ec0b2b48ef803df4103ve
+      url:
+          type: string
+          description: URL of the payment request created
+          example: https://pay.brevo.com/payment/6d4ec0b2b48ef803df4103ve
+
+  uploadImageModel:
+    type: object
+    required:
+      - url
+    properties:
+      url:
+        type: string
+        format: string
+        description: URL of the image uploaded
+        example: 'https://img.mailinblue.com/100000/images/rnb/original/62casdase8wewq9df1c2f27c.jpeg'
+
+  createUpdateContactModel:
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the contact when a new contact is created
+        example: 122
+
+  updateBatchContactsModel:
+    properties:
+      successIds:
+        type: array
+        items:
+          type: integer
+          description: IDs which are successfully updated
+          format: int64
+        example: 1,2
+      failureIds:
+        type: array
+        items:
+          type: integer
+          description: IDs which are not updated
+          format: int64
+        example: 3,4
+
+  createSenderModel:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the Sender created
+        example: 5
+      spfError:
+        type: boolean
+        description: Status of SPF configuration for the sender (true = SPF not well configured, false = SPF well configured)
+        example: true
+      dkimError:
+        type: boolean
+        description: Status of DKIM configuration for the sender (true = DKIM not well configured, false = DKIM well configured)
+        example: false
+
+  createDomainModel:
+      required:
+        - id
+      type: object
+      properties:
+        id:
+          type: integer
+          description: ID of the Domain created
+          format: int64
+          example: 5
+        domain_name:
+          type: string
+          description: Domain
+          example: example.com
+        domain_provider:
+          type: string
+          description: Domain Provider
+          example: GoDaddy
+        message:
+          type: string
+          description: Success message
+          example: Domain added successfully. To authenticate it, add following DNS records
+        dns_records:
+          type: object
+          properties:
+            dkim_record:
+              type: object
+              properties:
+                type:
+                  type: string
+                value:
+                  type: string
+                host_name:
+                  type: string
+                status:
+                  type: boolean
+            brevo_code:
+              type: object
+              properties:
+                type:
+                  type: string
+                value:
+                  type: string
+                host_name:
+                  type: string
+                status:
+                  type: boolean
+            dmarc_record:
+              type: object
+              properties:
+                type:
+                  type: string
+                value:
+                  type: string
+                host_name:
+                  type: string
+                status:
+                  type: boolean
+
+  authenticateDomainModel:
+    required:
+      - domain_name
+      - message
+    type: object
+    properties:
+      domain_name:
+        type: string
+        description: Domain
+        example: myexample.com
+      message:
+        type: string
+        description: Success message
+        example: Domain has been authenticated successfully.
+
+  getDomainConfigurationModel:
+    required:
+      - domain
+      - verified
+      - authenticated
+      - dns_records
+    type: object
+    properties:
+      domain:
+        type: string
+        description: Domain
+        example: myexample.com
+      verified:
+        type: boolean
+        description: Status of domain verification (true=verified, false=non verified)
+        example: true
+      authenticated:
+        type: boolean
+        description: Status of domain authentication (true=authenticated, false=non authenticated)
+        example: false
+      dns_records:
+        type: object
+        properties:
+          dkim_record:
+            type: object
+            properties:
+              type:
+                type: string
+              value:
+                type: string
+              host_name:
+                type: string
+              status:
+                type: boolean
+          brevo_code:
+            type: object
+            properties:
+              type:
+                type: string
+              value:
+                type: string
+              host_name:
+                type: string
+              status:
+                type: boolean
+          dmarc_record:
+            type: object
+            properties:
+              type:
+                type: string
+              value:
+                type: string
+              host_name:
+                type: string
+              status:
+                type: boolean
+
+  createSmtpEmail:
+    type: object
+    properties:
+      messageId:
+        type: string
+        description: Message ID of the transactional email sent
+        example: <201798300811.5787683@relay.domain.com>
+      messageIds:
+        type: array
+        items:
+          type: string
+          description: version wise message ID's of the transactional emails sent
+          example: ['<201798300811.5787683@relay.domain.com>','<201798300811.5787683@relay.domain.com>']
+
+  templatePreview:
+    type: object
+    properties:
+      fromEmail:
+        type: string
+        description: Sender email address
+        example: nikon.doe@example.com
+      fromName:
+        type: string
+        description: Sender name
+        example: Nikon Doe
+      html:
+        type: string
+        description: Html content of the template
+        example: <!DOCTYPE html><html><head><title>Preview html content</title></head><body><p>html content</p></body></html>
+      subject:
+        type: string
+        description: subject of the template
+        example: Template preview subject
+      usedFeedNames:
+        type: array
+        items:
+          type: string
+          description: feeds alias used in the template
+          example: ['feed_1','feed_2']
+      previewText:
+        type: string
+        description: Preview text of the template
+        example: Preview text
+
+  scheduleSmtpEmail:
+    type: object
+    properties:
+      messageId:
+        type: string
+        description: Message ID of the transactional email scheduled
+        example: <201798300811.5787683@relay.domain.com>
+      messageIds:
+        type: array
+        items:
+          type: string
+          description: version wise message ID's of the transactional emails scheduled
+      batchId:
+        type: string
+        description: Batch ID of the batch transactional email scheduled
+        example: 5c6cfa04-eed9-42c2-8b5c-6d470d978e9d
+
+  sendSms :
+    type: object
+    required:
+      - reference
+      - messageId
+    properties:
+      reference:
+        type: string
+        example: 'ab1cde2fgh3i4jklmno'
+      messageId:
+        type: integer
+        format: int64
+        example: 1511882900176220
+      smsCount:
+        type: integer
+        format: int64
+        description: Count of SMS's to send multiple text messages
+        example: 2
+      usedCredits:
+        type: number
+        format: float
+        description: SMS credits used per text message
+        example: 0.70
+      remainingCredits:
+        type: number
+        format: float
+        description: Remaining SMS credits of the user
+        example: 82.85
+
+  createdProcessId:
+    type: object
+    required:
+      - processId
+    properties:
+      processId:
+        type: integer
+        format: int64
+        description: Id of the process created
+        example: 78
+
+  createUpdateFolder:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Name of the folder
+        example: 'Wordpress Contacts'
+
+  postSendFailed :
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int64
+        description: Response code
+        example: 'invalid_parameter'
+      message:
+        type: string
+        description: Response message
+        example: 'The email could not be sent to all recipients'
+      unexistingEmails :
+        type: array
+        items :
+          type: string
+          format: email
+          description: Email addresses you tried to sent an email to, but not existing in your contacts
+          example: "matthew.dow@example.com, elisa.carrely@example.com"
+      withoutListEmails :
+        type: array
+        items :
+          type: string
+          format: email
+          description: Email addresses you sent an email to, without a contact list
+          example: "jeff.dean@example.com, jim.sue@example.com"
+      blackListedEmails :
+        type: array
+        items :
+          type: string
+          format: email
+          description: Email addresses which are blacklisted. ONLY FOR email-campign's sendTest OR smtp-template's sendTest api's.
+          example: "jeff.dean@example.com, jim.sue@example.com"
+
+  postSendSmsTestFailed :
+    type: object
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int64
+        description: Response code
+        example: 'invalid_parameter'
+      message:
+        type: string
+        description: Response message
+        example: 'The SMS could not be sent to all recipients'
+      unexistingSms :
+        type: array
+        items :
+          type: string
+          format: email
+          description: Email addresses you tried to sent a SMS to, but not existing in your contacts
+          example: "337699086644@mailin.com, 41778899954@mailin.com"
+      withoutListSms :
+        type: array
+        items :
+          type: string
+          format: email
+          description: Email addresses you sent a SMS to, without a contact list
+          example: "3542388988@mailin.com, 10976444477@mailin.com"
+
+  postContactInfo :
+    type: object
+    required:
+      - contacts
+    properties:
+      contacts:
+        type: object
+        properties:
+          success:
+            type: array
+            items :
+              type: string
+              format: email
+              description: Email addresses which are successfully imported
+              example: "jeff32@example.com, jim56@example.com"
+          failure:
+            type: array
+            items :
+              type: string
+              format: email
+              description: Email addresses which can not be imported, could be already in/out list and/or doesn't exist
+              example: "jeff32@example.com, jim56@example.com"
+          total:
+            type: integer
+            format: int64
+            description: Displays the count of total number of contacts removed from list when user opts for "all" option.
+            example: 27
+          processId:
+            type: integer
+            format: int64
+            description: Id of the process created to remove contacts from list when user opts for "all" option.
+            example: 78
+
+  getAggregatedReport:
+    type: object
+    properties:
+      range:
+        type: string
+        description: Time frame of the report
+        example: '2016-09-08|2017-04-06'
+      requests:
+        type: integer
+        format: int64
+        description: Number of requests for the timeframe
+        example: 263
+      delivered:
+        type: integer
+        format: int64
+        description: Number of delivered emails for the timeframe
+        example: 249
+      hardBounces:
+        type: integer
+        format: int64
+        description: Number of hardbounces for the timeframe
+        example: 1
+      softBounces:
+        type: integer
+        format: int64
+        description: Number of softbounces for the timeframe
+        example: 4
+      clicks:
+        type: integer
+        format: int64
+        description: Number of clicks for the timeframe
+        example: 12
+      uniqueClicks:
+        type: integer
+        format: int64
+        description: Number of unique clicks for the timeframe
+        example: 8
+      opens:
+        type: integer
+        format: int64
+        description: Number of openings for the timeframe
+        example: 47
+      uniqueOpens:
+        type: integer
+        format: int64
+        description: Number of unique openings for the timeframe
+        example: 37
+      spamReports:
+        type: integer
+        format: int64
+        description: Number of complaint (spam report) for the timeframe
+        example: 0
+      blocked:
+        type: integer
+        format: int64
+        description: Number of blocked contact emails for the timeframe
+        example: 2
+      invalid:
+        type: integer
+        format: int64
+        description: Number of invalid emails for the timeframe
+        example: 0
+      unsubscribed:
+        type: integer
+        format: int64
+        description: Number of unsubscribed emails for the timeframe
+        example: 0
+  getTransacBlockedContacts:
+    type: object
+    properties:
+      count:
+        type: integer
+        format: int64
+        description: Count of blocked or unsubscribed contact
+        example: 1
+      contacts:
+        type: array
+        items:
+          type: object
+          required:
+            - email
+            - senderEmail
+            - reason
+            - blockedAt
+          properties:
+            email:
+              type: string
+              format: email
+              description: Email address of the blocked or unsubscribed contact
+              example: 'john.smith@example.com'
+            senderEmail:
+              type: string
+              format: email
+              description: Sender email address of the blocked or unsubscribed contact
+              example: 'john.smith@example.com'
+            reason:
+              type: string
+              description: Reason for blocking / unsubscribing
+              example: 'Admin blocked'
+              properties:
+                code:
+                  type: string
+                  enum:
+                   - unsubscribedViaMA
+                   - unsubscribedViaEmail
+                   - adminBlocked
+                   - unsubscribedViaApi
+                   - hardBounce
+                   - contactFlaggedAsSpam
+                  description: Reason code for blocking / unsubscribing (This code is safe for comparison)
+                  example: 'AdminBlocked'
+                message:
+                  type: string
+                  description: Reason for blocking / unsubscribing (This string is not safe for comparison)
+                  example: Admin blocked
+            blockedAt:
+              type: string
+              description: Date when the contact was blocked or unsubscribed on
+              example: '2017-05-01T12:30:00Z'
+
+  getReports:
+    type: object
+    properties:
+      reports:
+        type: array
+        items:
+          type: object
+          required:
+            - date
+            - requests
+            - delivered
+            - hardBounces
+            - softBounces
+            - clicks
+            - uniqueClicks
+            - opens
+            - uniqueOpens
+            - spamReports
+            - blocked
+            - invalid
+            - unsubscribed
+          properties:
+            date:
+              type: string
+              format: date
+              description: Date of the statistics
+              example: '2017-04-06'
+            requests:
+              type: integer
+              format: int64
+              description: Number of requests for the date
+              example: 65
+            delivered:
+              type: integer
+              format: int64
+              description: Number of delivered emails for the date
+              example: 63
+            hardBounces:
+              type: integer
+              format: int64
+              description: Number of hardbounces for the date
+              example: 1
+            softBounces:
+              type: integer
+              format: int64
+              description: Number of softbounces for the date
+              example: 1
+            clicks:
+              type: integer
+              format: int64
+              description: Number of clicks for the date
+              example: 6
+            uniqueClicks:
+              type: integer
+              format: int64
+              description: Number of unique clicks for the date
+              example: 5
+            opens:
+              type: integer
+              format: int64
+              description: Number of openings for the date
+              example: 58
+            uniqueOpens:
+              type: integer
+              format: int64
+              description: Number of unique openings for the date
+              example: 52
+            spamReports:
+              type: integer
+              format: int64
+              description: Number of complaints (spam reports) for the date
+              example: 0
+            blocked:
+              type: integer
+              format: int64
+              description: Number of blocked emails for the date
+              example: 0
+            invalid:
+              type: integer
+              format: int64
+              description: Number of invalid emails for the date
+              example: 0
+            unsubscribed:
+              type: integer
+              format: int64
+              description: Number of unsubscribed emails for the date
+              example: 0
+
+  getEmailEventReport:
+    type: object
+    properties:
+      events:
+        type: array
+        items:
+          type: object
+          required:
+            - email
+            - date
+            - messageId
+            - event
+          properties:
+            email:
+              type: string
+              format: email
+              description: Email address which generates the event
+              example: 'john.smith@example.com'
+            date:
+              type: string
+              description: UTC date-time on which the event has been generated
+              example: '2017-03-12T12:30:00Z'
+            subject:
+              type: string
+              description: Subject of the event
+              example: 'Sib client test'
+            messageId:
+              type: string
+              description: Message ID which generated the event
+              example: '<201798300811.5787683@relay.domain.com>'
+            event:
+              type: string
+              enum:
+                - bounces
+                - hardBounces
+                - softBounces
+                - delivered
+                - spam
+                - requests
+                - opened
+                - clicks
+                - invalid
+                - deferred
+                - blocked
+                - unsubscribed
+                - error
+                - loadedByProxy
+              description: Event which occurred
+              example: 'delivered'
+            reason:
+              type: string
+              description: Reason of bounce (only available if the event is hardbounce or softbounce)
+              example: 'Error connection timeout'
+            tag:
+              type: string
+              description: Tag of the email which generated the event
+              example: 'OrderConfirmation'
+            ip:
+              type: string
+              description: IP from which the user has opened the email or clicked on the link (only available if the event is opened or clicks)
+              example: '165.87.3.15'
+            link:
+              type: string
+              description: The link which is sent to the user (only available if the event is requests or opened or clicks)
+              example: 'https://www.someexamplelink.com'
+            from:
+              type: string
+              format: email
+              description: Sender email from which the emails are sent
+              example: 'john@example.com'
+            templateId:
+              type: integer
+              description: ID of the template (only available if the email is template based)
+              format: int64
+              example: 4
+
+  getSmsEventReport:
+    type: object
+    properties:
+      events:
+        type: array
+        items:
+          type: object
+          properties:
+            phoneNumber:
+              type: string
+              description: Phone number which has generated the event
+              example : '00189001094'
+            date:
+              type: string
+              description: UTC date-time on which the event has been generated
+              example: '2017-03-12T12:30:00Z'
+            messageId:
+              type: string
+              description: Message ID which generated the event
+              example: '1472640582425378'
+            event:
+              type: string
+              enum:
+                - bounces
+                - hardBounces
+                - softBounces
+                - delivered
+                - sent
+                - accepted
+                - unsubscription
+                - replies
+                - blocked
+                - rejected
+                - skipped
+              description: Event which occurred
+              example: 'accepted'
+            reason:
+              type: string
+              description: Reason of bounce (only available if the event is hardbounce or softbounce)
+              example: 'Message is undeliverable due to an incorrect / invalid / blacklisted / permanently barred MSISDN for this operator'
+            reply:
+              type: string
+            tag:
+              type: string
+              description: Tag of the SMS which generated the event
+              example: 'CabWaiting'
+
+
+  getSmtpTemplateOverview:
+    type: object
+    required:
+     - id
+     - name
+     - subject
+     - isActive
+     - testSent
+     - sender
+     - replyTo
+     - toField
+     - tag
+     - htmlContent
+     - createdAt
+     - modifiedAt
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the template
+        example: 4
+      name:
+        type: string
+        description: Name of the template
+        example: 'Order Confirmation - EN'
+      subject:
+        type: string
+        description: Subject of the template
+        example: 'Thanks for your order !'
+      isActive:
+        type: boolean
+        description: Status of template (true=active, false=inactive)
+        example: true
+      testSent:
+        type: boolean
+        description: Status of test sending for the template (true=test email has been sent, false=test email has not been sent)
+        example: true
+      sender:
+        type: object
+        properties:
+          name:
+            description:  From email for the template
+            type: string
+            example: 'Mary form MyShop'
+          email:
+            description: From email for the template
+            type: string
+            format: email
+            example: 'contact@myshop.fr'
+          id:
+            description: Sender id of the template
+            type: string
+            example: 43
+      replyTo:
+        type: string
+        format: email
+        description: Email defined as the "Reply to" for the template
+        example: 'replyto@domain.com'
+      toField:
+        type: string
+        description: Customisation of the "to" field for the template
+        example: '{FIRSTNAME} {LASTNAME}'
+      tag:
+        type: string
+        description: Tag of the template
+        example: 'sports'
+      htmlContent:
+         type: string
+         description: HTML content of the template
+         example: 'Your order n°xxxxx has been confirmed. Thanks for your purchase.'
+      createdAt:
+        type: string
+        description: Creation UTC date-time of the template (YYYY-MM-DDTHH:mm:ss.SSSZ)
+        example: '2017-05-01T12:30:00Z'
+      modifiedAt:
+        type: string
+        description: Last modification UTC date-time of the template (YYYY-MM-DDTHH:mm:ss.SSSZ)
+        example: '2017-05-12T12:30:00Z'
+      doiTemplate:
+        type: boolean
+        description: It is true if template is a valid Double opt-in (DOI) template, otherwise it is false. This field will be available only in case of single template detail call.
+        example: false
+
+  getSmtpTemplates:
+    type: object
+    properties:
+      count:
+        type: integer
+        format: int64
+        description: Count of transactional email templates
+        example: 1
+      templates:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/getSmtpTemplateOverview'
+
+  getWebhook:
+    type: object
+    required:
+      - url
+      - id
+      - description
+      - events
+      - type
+      - createdAt
+      - modifiedAt
+    properties:
+      url:
+        type: string
+        format: url
+        description: URL of the webhook
+        example: 'http://requestb.in/173lyyx1'
+      id:
+        type: integer
+        format: int64
+        description: ID of the webhook
+        example: 654
+      description:
+        type: string
+        description: Description of the webhook
+        example: 'Webhook triggered on campaign openings'
+      events:
+        type: array
+        items:
+          type: string
+          description: Events which will trigger the webhook when they occure
+          example: "opens,clicks"
+      type:
+        type: string
+        enum:
+          - marketing
+          - transactional
+        description: Type of webhook (marketing or transactional)
+        example: marketing
+      createdAt:
+        type: string
+        description: Creation UTC date-time of the webhook (YYYY-MM-DDTHH:mm:ss.SSSZ)
+        example: '2016-12-01T12:50:00Z'
+      modifiedAt:
+        type: string
+        description: Last modification UTC date-time of the webhook (YYYY-MM-DDTHH:mm:ss.SSSZ)
+        example: '2017-05-12T13:15:00Z'
+      batched:
+        description: To send batched webhooks
+        type: boolean
+        example: true
+      auth:
+        description: Add authentication on webhook url
+        type: object
+        properties:
+          type:
+            description: Type of authentication
+            type: string
+            example: bearer
+          token:
+            description: Webhook authentication token
+            type: string
+            example: test-auth-token1234
+      headers:
+        description: Custom headers to be send with webhooks
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              description: Header key name
+              type: string
+              example: cf-secret
+            value:
+              description: Header value
+              type: string
+              example: test-header-value
+
+  getWebhooks:
+    type: object
+    required:
+      - webhooks
+    properties:
+      webhooks:
+        type: array
+        items:
+          type: object
+          allOf:
+            - $ref: '#/definitions/getWebhook'
+
+  getContactDetails:
+    type: object
+    required:
+      - id
+      - emailBlacklisted
+      - smsBlacklisted
+      - createdAt
+      - modifiedAt
+      - listIds
+      - attributes
+    properties:
+      email:
+        type: string
+        format: email
+        description: Email address of the contact for which you requested the details
+        example: 'john.smith@example.com'
+      id:
+        type: integer
+        format: int64
+        description: ID of the contact for which you requested the details
+        example: 32
+      emailBlacklisted:
+        type: boolean
+        description: Blacklist status for email campaigns (true=blacklisted, false=not blacklisted)
+        example: false
+      smsBlacklisted:
+        type: boolean
+        description: Blacklist status for SMS campaigns (true=blacklisted, false=not blacklisted)
+        example: true
+      createdAt:
+        type: string
+        description: Creation UTC date-time of the contact (YYYY-MM-DDTHH:mm:ss.SSSZ)
+        example: '2017-05-12T12:30:00Z'
+      modifiedAt:
+        type: string
+        description: Last modification UTC date-time of the contact (YYYY-MM-DDTHH:mm:ss.SSSZ)
+        example: '2017-05-12T12:30:00Z'
+      listIds:
+        type: array
+        items:
+          type: integer
+          format: int64
+          description: List(s) in which the contact is included
+          example: 12,9,20
+      listUnsubscribed:
+        type: array
+        items:
+          type: integer
+          format: int64
+          description: List(s) in which the contact is included (only available if unsubscription per list is activated for the account)
+          example: 1,2
+      attributes:
+        type: object
+        description: Set of attributes of the contact
+        example: {"name":"Joe", "email":"joe@example.com"}
+
+  getExtendedContactDetails:
+    allOf:
+      - $ref: '#/definitions/getContactDetails'
+      - type: object
+        required:
+          - statistics
+        properties:
+          statistics:
+            type: object
+            description: Campaign statistics of the contact
+            properties:
+              messagesSent:
+                description : Listing of the sent campaign for the contact
+                type: array
+                items:
+                  type: object
+                  required:
+                    - campaignId
+                    - eventTime
+                  properties:
+                    campaignId:
+                      type: integer
+                      format: int64
+                      description : ID of the campaign which generated the event
+                      example: 3
+                    eventTime:
+                      type: string
+                      description: UTC date-time of the event
+                      example: '2017-03-12T20:15:13Z'
+              hardBounces:
+                type: array
+                description : Listing of the hardbounes generated by the contact
+                items:
+                  type: object
+                  required:
+                    - campaignId
+                    - eventTime
+                  properties:
+                    campaignId:
+                      type: integer
+                      format: int64
+                      description : ID of the campaign which generated the event
+                      example: 3
+                    eventTime:
+                      type: string
+                      description: UTC date-time of the event
+                      example: '2017-03-12T20:15:13Z'
+              softBounces:
+                type: array
+                description : Listing of the softbounes generated by the contact
+                items:
+                  type: object
+                  required:
+                    - campaignId
+                    - eventTime
+                  properties:
+                    campaignId:
+                      type: integer
+                      format: int64
+                      description : ID of the campaign which generated the event
+                      example: 3
+                    eventTime:
+                      type: string
+                      description: UTC date-time of the event
+                      example: '2017-03-12T20:15:13Z'
+              complaints:
+                type: array
+                description : Listing of the complaints generated by the contact
+                items:
+                  type: object
+                  required:
+                    - campaignId
+                    - eventTime
+                  properties:
+                    campaignId:
+                      type: integer
+                      format: int64
+                      description : ID of the campaign which generated the event
+                      example: 3
+                    eventTime:
+                      type: string
+                      description: UTC date-time of the event
+                      example: '2017-03-12T20:15:13Z'
+              unsubscriptions:
+                type: object
+                description : Listing of the unsubscription for the contact
+                required:
+                  - userUnsubscription
+                  - adminUnsubscription
+                properties:
+                  userUnsubscription:
+                    description: Contact unsubscribe via unsubscription link in a campaign
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - campaignId
+                        - eventTime
+                      properties:
+                        campaignId:
+                          type: integer
+                          format: int64
+                          description : ID of the campaign which generated the event
+                          example: 3
+                        eventTime:
+                          type: string
+                          description: UTC date-time of the event
+                          example: '2017-03-12T20:15:13Z'
+                        ip:
+                          type: string
+                          description : IP from which the user has unsubscribed
+                          example: '165.87.3.15'
+                  adminUnsubscription:
+                    type: array
+                    description : Contact has been unsubscribed from the administrator
+                    items:
+                      type: object
+                      required:
+                        - eventTime
+                      properties:
+                        eventTime:
+                          type: string
+                          description: UTC date-time of the event
+                          example: '2017-03-12T20:15:13Z'
+                        ip:
+                          type: string
+                          description : IP from which the user has been unsubscribed
+                          example: '165.87.3.15'
+              opened:
+                type: array
+                description : Listing of the openings generated by the contact
+                items:
+                  type: object
+                  required:
+                    - campaignId
+                    - count
+                    - eventTime
+                    - ip
+                  properties:
+                    campaignId:
+                      type: integer
+                      format: int64
+                      description : ID of the campaign which generated the event
+                      example: 3
+                    count:
+                      type: integer
+                      format: int64
+                      description: Number of openings for the campaign
+                      example: 1
+                    eventTime:
+                      type: string
+                      description: UTC date-time of the event
+                      example: '2017-03-12T20:15:13Z'
+                    ip:
+                      type: string
+                      description : IP from which the user has opened the email
+                      example: '165.87.3.15'
+              clicked:
+                type: array
+                description : Listing of the clicks generated by the contact
+                items:
+                  type: object
+                  required:
+                    - campaignId
+                    - links
+                  properties:
+                    campaignId:
+                        type: integer
+                        format: int64
+                        description : ID of the campaign which generated the event
+                        example: 3
+                    links:
+                      type: array
+                      description: Listing of the clicked links for the campaign
+                      items:
+                        type: object
+                        required:
+                          - count
+                          - eventTime
+                          - ip
+                          - url
+                        properties:
+                          count:
+                            type: integer
+                            format: int64
+                            description: Number of clicks on this link for the campaign
+                            example: 1
+                          eventTime:
+                            type: string
+                            description: UTC date-time of the event
+                            example: '2017-03-12T20:15:13Z'
+                          ip:
+                            type: string
+                            description : IP from which the user has clicked on the link
+                            example: '165.87.3.15'
+                          url:
+                            type: string
+                            description : URL of the clicked link
+                            example: 'www.myshop.com'
+              transacAttributes:
+                type: array
+                description : Listing of the transactional attributes for the contact
+                items:
+                  type: object
+              delivered:
+                type: array
+                description: Listing of the delivered campaign for the contact
+                items:
+                  required:
+                  - campaignId
+                  - eventTime
+                  type: object
+                  properties:
+                    campaignId:
+                      type: integer
+                      description: ID of the campaign which generated the event
+                      format: int64
+                      example: 3
+                    eventTime:
+                      type: string
+                      description: UTC date-time of the event
+                      example: 2017-03-12T20:15:13Z
+
+  getContactCampaignStats:
+    type: object
+    description: Campaign Statistics for the contact
+    properties:
+      messagesSent:
+        type: array
+        items:
+          type: object
+          required:
+            - campaignId
+            - eventTime
+          properties:
+            campaignId:
+              type: integer
+              format: int64
+              description : ID of the campaign which generated the event
+              example: 3
+            eventTime:
+              type: string
+              description: UTC date-time of the event
+              example: '2017-03-12T20:15:13Z'
+      hardBounces:
+        type: array
+        items:
+          type: object
+          required:
+            - campaignId
+            - eventTime
+          properties:
+            campaignId:
+              type: integer
+              format: int64
+              description : ID of the campaign which generated the event
+              example: 3
+            eventTime:
+              type: string
+              description: UTC date-time of the event
+              example: '2017-03-12T20:15:13Z'
+      softBounces:
+        type: array
+        items:
+          type: object
+          required:
+            - campaignId
+            - eventTime
+          properties:
+            campaignId:
+              type: integer
+              format: int64
+              description : ID of the campaign which generated the event
+              example: 3
+            eventTime:
+              type: string
+              description: UTC date-time of the event
+              example: '2017-03-12T20:15:13Z'
+      complaints:
+        type: array
+        items:
+          type: object
+          required:
+            - campaignId
+            - eventTime
+          properties:
+            campaignId:
+              type: integer
+              format: int64
+              description : ID of the campaign which generated the event
+              example: 3
+            eventTime:
+              type: string
+              description: UTC date-time of the event
+              example: '2017-03-12T20:15:13Z'
+      unsubscriptions:
+        type: object
+        required:
+          - userUnsubscription
+          - adminUnsubscription
+        properties:
+          userUnsubscription:
+            type: array
+            description: Contact has unsubscribed via the unsubscription link in the email
+            items:
+              type: object
+              required:
+                - campaignId
+                - eventTime
+              properties:
+                campaignId:
+                  type: integer
+                  format: int64
+                  description : ID of the campaign which generated the event
+                  example: 3
+                eventTime:
+                  type: string
+                  description: UTC date-time of the event
+                  example: '2017-03-12T20:15:13Z'
+                ip:
+                  type: string
+                  description : IP from which the user has unsubscribed
+                  example: 165.87.3.15
+          adminUnsubscription:
+            type: array
+            description: Contact has been unsubscribed from the administrator
+            items:
+              type: object
+              required:
+                - eventTime
+              properties:
+                eventTime:
+                  type: string
+                  description: UTC date-time of the event
+                  example: '2017-03-12T20:15:13Z'
+                ip:
+                  type: string
+                  description : IP from which the user has been unsubscribed
+                  example: '165.87.3.15'
+      opened:
+        type: array
+        items:
+          type: object
+          required:
+            - campaignId
+            - count
+            - eventTime
+            - ip
+          properties:
+            campaignId:
+              type: integer
+              format: int64
+              description : ID of the campaign which generated the event
+              example: 3
+            count:
+              type: integer
+              format: int64
+              description : Number of openings of the campaign
+              example: 3
+            eventTime:
+              type: string
+              description: UTC date-time of the event
+              example: '2017-03-12T20:15:13Z'
+            ip:
+              type: string
+              description : IP from which the user has opened the campaign
+              example: '165.87.3.15'
+      clicked:
+        type: array
+        items:
+          type: object
+          required:
+            - campaignId
+            - links
+          properties:
+            campaignId:
+                type: integer
+                format: int64
+                description : ID of the campaign which generated the event
+                example: 3
+            links:
+              type: array
+              items:
+                type: object
+                required:
+                  - count
+                  - eventTime
+                  - ip
+                  - url
+                properties:
+                  count:
+                    type: integer
+                    format: int64
+                    description: Number of clicks on this link for the campaign
+                    example: 1
+                  eventTime:
+                    type: string
+                    description: UTC date-time of the event
+                    example: '2017-03-12T20:15:13Z'
+                  ip:
+                    type: string
+                    description : IP from which the user has clicked on the link
+                    example: '165.87.3.15'
+                  url:
+                    type: string
+                    description : URL of the clicked link
+                    example: 'www.myshop.com'
+      transacAttributes:
+        type: array
+        items:
+          type: object
+          required:
+            - orderDate
+            - orderPrice
+            - orderId
+          properties:
+            orderDate:
+              type: string
+              format: date
+              description: Date of the order
+              example: '2017-03-12'
+            orderPrice:
+              type: number
+              format: float
+              description: Price of the order
+              example: 24.99
+            orderId:
+              type: integer
+              format: int64
+              description: ID of the order
+              example: 248
+      delivered:
+        type: array
+        items:
+          type: object
+          required:
+            - campaignId
+            - eventTime
+          properties:
+            campaignId:
+              type: integer
+              format: int64
+              description : ID of the campaign which generated the event
+              example: 3
+            eventTime:
+              type: string
+              description: UTC date-time of the event
+              example: '2017-03-12T20:15:13Z'
+
+  getContacts:
+    type: object
+    required:
+      - contacts
+      - count
+    properties:
+      contacts:
+        type: array
+        items:
+          type: object
+          allOf:
+            - $ref: '#/definitions/getContactDetails'
+      count:
+        type: integer
+        format: int64
+        description: Number of contacts
+        example: 17655
+
+  getAttributes:
+    type: object
+    required:
+      - attributes
+    properties:
+      attributes:
+        type: array
+        description : Listing of available contact attributes in your account
+        items:
+          type: object
+          required:
+            - name
+            - category
+          properties:
+            name:
+              type: string
+              description: Name of the attribute
+              example: 'LASTNAME'
+            category:
+              type: string
+              enum:
+                - normal
+                - transactional
+                - category
+                - calculated
+                - global
+              description: Category of the attribute
+              example: 'category'
+            type:
+              type: string
+              enum:
+                - text
+                - date
+                - float
+                - id
+                - boolean
+                - multiple-choice
+                - user
+              description: Type of the attribute
+              example: 'text'
+            enumeration:
+              type: array
+              description: Parameter only available for "category" type attributes.
+              items:
+                type: object
+                required:
+                  - value
+                  - label
+                properties:
+                  value:
+                    type: integer
+                    format: int64
+                    description: ID of Value of the "category" type attribute
+                    example: 1
+                  label:
+                    type: string
+                    description: Label of the "category" type attribute
+                    example: 'Women'
+            calculatedValue:
+              type: string
+              description: Calculated value formula
+              example: 'COUNT[ORDER_ID,ORDER_DATE,==,NOW(-1)]'
+            multiCategoryOptions:
+              type: array
+              description: Parameter only available for "multiple-choice" type attributes.
+              items:
+                type: string
+                description: Options of the "multiple-choice" type attribute
+                example: USA
+
+  getFolders:
+    type: object
+    properties:
+      folders:
+        type: array
+        items:
+          type: object
+          allOf:
+            - $ref: '#/definitions/getFolder'
+      count:
+        type: integer
+        format: int64
+        description: Number of folders available in your account
+        example: 10
+
+  getSegments:
+    type: object
+    properties:
+      segments:
+        type: array
+        items:
+          type: object
+          allOf:
+            - $ref: '#/definitions/getSegment'
+      count:
+        type: integer
+        format: int64
+        description: Number of Segments available in your account
+        example: 10
+
+  getSegment:
+    type: object
+    required:
+      - id
+      - segmentName
+      - categoryName
+    properties:
+      id:
+        type: integer
+        description: ID of the segment
+        format: int64
+        example: 23
+      segmentName:
+        type: string
+        description: Name of the Segment
+        example: My Segment
+      categoryName:
+        type: string
+        description: Name of the Segment Category
+        format: string
+        example: New Category
+      updatedAt:
+        type: string
+        description: Updation UTC date-time of the segment (YYYY-MM-DDTHH:mm:ss.SSSZ)
+        example: '2017-03-13T17:05:09Z'
+
+  getFolder:
+    type: object
+    required:
+      - id
+      - name
+      - totalBlacklisted
+      - totalSubscribers
+      - uniqueSubscribers
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the folder
+        example: 2
+      name:
+        type: string
+        description: Name of the folder
+        example: 'Magento Customers'
+      totalBlacklisted:
+        type: integer
+        format: int64
+        description: Number of blacklisted contacts in the folder
+        example: 32
+      totalSubscribers:
+        type: integer
+        format: int64
+        description: Number of contacts in the folder
+        example: 19777
+      uniqueSubscribers:
+        type: integer
+        format: int64
+        description: Number of unique contacts in the folder
+        example: 16222
+
+  getFolderLists:
+    type: object
+    properties:
+      lists:
+        type: array
+        items:
+          type: object
+          allOf:
+            - $ref: '#/definitions/getList'
+      count:
+        type: integer
+        format: int64
+        description: Number of lists in the folder
+        example: 6
+
+  getLists:
+    type: object
+    properties:
+      lists:
+        type: array
+        description: Listing of all the lists available in your account
+        items:
+          type: object
+          allOf:
+          - $ref: '#/definitions/getList'
+          - type: object
+            required:
+              - folderId
+            properties:
+              folderId:
+                type: integer
+                format: int64
+                description: ID of the folder
+                example: 2
+      count:
+        type: integer
+        format: int64
+        description: Number of lists in your account
+        example: 150
+
+  getList:
+    type: object
+    required:
+      - id
+      - name
+      - totalSubscribers
+      - totalBlacklisted
+      - uniqueSubscribers
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the list
+        example: 23
+      name:
+        type: string
+        description: Name of the list
+        example: 'Magento Customers - EN'
+      totalBlacklisted:
+        type: integer
+        format: int64
+        description: Number of blacklisted contacts in the list
+        example: 13
+      totalSubscribers:
+        type: integer
+        format: int64
+        description: Number of contacts in the list
+        example: 1776
+      uniqueSubscribers:
+        type: integer
+        format: int64
+        description: Number of unique contacts in the list
+        example: 1789
+
+  getExtendedList:
+    allOf:
+      - $ref: '#/definitions/getList'
+      - type: object
+        required:
+          - folderId
+          - createdAt
+        properties:
+          folderId:
+            type: integer
+            format: int64
+            description: ID of the folder
+            example: 2
+          createdAt:
+            type: string
+            description: Creation UTC date-time of the list (YYYY-MM-DDTHH:mm:ss.SSSZ)
+            example: '2017-03-13T17:05:09Z'
+          campaignStats:
+            type: array
+            items:
+              type: object
+              required:
+                - campaignId
+                - stats
+              properties:
+                campaignId:
+                  type: integer
+                  format: int64
+                  description : ID of the campaign
+                  example: 143
+                stats:
+                  $ref: '#/definitions/getCampaignStats'
+          dynamicList:
+            type: boolean
+            description: Status telling if the list is dynamic or not (true=dynamic, false=not dynamic)
+            example: false
+
+  getSmsCampaignStats:
+    type: object
+    required:
+      - delivered
+      - sent
+      - processing
+      - softBounces
+      - hardBounces
+      - unsubscriptions
+      - answered
+    properties:
+      delivered:
+        type: integer
+        format: int64
+        description: Number of delivered SMS
+        example: 2987
+      sent:
+        type: integer
+        format: int64
+        description: Number of sent SMS
+        example: 3000
+      processing:
+        type: integer
+        format: int64
+        description: Number of processing SMS
+        example: 0
+      softBounces:
+        type: integer
+        format: int64
+        description: Number of softbounced SMS
+        example: 3
+      hardBounces:
+        type: integer
+        format: int64
+        description: Number of hardbounced SMS
+        example: 1
+      unsubscriptions:
+        type: integer
+        format: int64
+        description: Number of unsubscription SMS
+        example: 3
+      answered:
+        type: integer
+        format: int64
+        description: Number of replies to the SMS
+        example: 2
+
+  getDeviceBrowserStats:
+    type: object
+    required:
+      - clickers
+      - uniqueClicks
+      - viewed
+      - uniqueViews
+    properties:
+      clickers:
+        type: integer
+        format: int64
+        description: Number of total clicks for the campaign using the particular browser
+        example: 2665
+      uniqueClicks:
+        type: integer
+        format: int64
+        description: Number of unique clicks for the campaign using the particular browser
+        example: 2300
+      viewed:
+        type: integer
+        format: int64
+        description: Number of openings for the campaign using the particular browser
+        example: 8999
+      uniqueViews:
+        type: integer
+        format: int64
+        description: Number of unique openings for the campaign using the particular browser
+        example: 7779
+
+  getCampaignStats:
+    type: object
+    required:
+      - uniqueClicks
+      - clickers
+      - complaints
+      - delivered
+      - sent
+      - softBounces
+      - hardBounces
+      - uniqueViews
+      - unsubscriptions
+      - viewed
+      - trackableViews
+      - opensRate
+      - appleMppOpens
+    properties:
+      listId:
+        type: integer
+        format: int64
+        description: List Id of email campaign (only in case of get email campaign(s)(not for global stats))
+        example: 2
+      uniqueClicks:
+        type: integer
+        format: int64
+        description: Number of unique clicks for the campaign
+        example: 2300
+      clickers:
+        type: integer
+        format: int64
+        description: Number of total clicks for the campaign
+        example: 2665
+      complaints:
+        type: integer
+        format: int64
+        description: Number of complaints (Spam reports) for the campaign
+        example: 1
+      delivered:
+        type: integer
+        format: int64
+        description: Number of delivered emails for the campaign
+        example: 19765
+      sent:
+        type: integer
+        format: int64
+        description: Number of sent emails for the campaign
+        example: 19887
+      softBounces:
+        type: integer
+        format: int64
+        description: Number of softbounce for the campaign
+        example: 100
+      hardBounces:
+        type: integer
+        format: int64
+        description: Number of harbounce for the campaign
+        example: 87
+      uniqueViews:
+        type: integer
+        format: int64
+        description: Number of unique openings for the campaign
+        example: 7779
+      trackableViews:
+        type: integer
+        description: Recipients without any privacy protection option enabled in their email client
+        format: int64
+        example: 5661
+      trackableViewsRate:
+        type: number
+        description: Rate of recipients without any privacy protection option enabled in their email client
+        format: float
+        example: 23.45
+      estimatedViews:
+        type: integer
+        description: Rate of recipients without any privacy protection option enabled in their email client, applied to all delivered emails
+        format: int64
+        example: 560
+      unsubscriptions:
+        type: integer
+        format: int64
+        description: Number of unsubscription for the campaign
+        example: 2
+      viewed:
+        type: integer
+        format: int64
+        description: Number of openings for the campaign
+        example: 8999
+      deferred:
+        type: integer
+        format: int64
+        description: Number of deferred emails for the campaign
+        example: 30
+      returnBounce:
+        description: Total number of non-delivered campaigns for a particular campaign id.
+        type: integer
+        format: int64
+        example: 5
+      opensRate:
+        type: number
+        description: Percentage of recipients who open the email out of your total number of recipients. Depending on your Campaign settings, they may include Apple MPP opens.
+        format: float
+        example: 29.54
+      appleMppOpens:
+        type: integer
+        description: Numbers of times your email has been opened automatically through Apple MPP.
+        format: int64
+        example: 10
+
+  updateSmtpTemplate:
+    type: object
+    properties:
+      tag:
+        description: Tag of the template
+        type: string
+        example: 'OrderConfirmation'
+      sender:
+        type: object
+        description: Sender details including id or email and name (optional). Only one of either Sender's email or Sender's ID shall be passed in one request at a time. For example `{"name":"xyz", "email":"example@abc.com"}` , `{"name":"xyz", "id":123}`
+        properties:
+          name:
+            description: Name of the sender
+            type: string
+            example: 'Mary from MyShop'
+          email:
+            description: Email of the sender
+            type: string
+            format: email
+            example: 'contact@myshop.com'
+          id:
+            description: Select the sender for the template on the basis of sender id. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id (instead of email).
+            type: integer
+            format: int64
+            example: 3
+      templateName:
+        description: Name of the template
+        type: string
+        example: 'Order Confirmation - EN'
+      htmlContent:
+        description: Required if htmlUrl is empty. If the template is designed using Drag & Drop editor via HTML content, then the design page will not have Drag & Drop editor access for that template. Body of the message (HTML must have more than 10 characters)
+        type: string
+        example: 'The order n°xxxxx has been confirmed. Thanks for your purchase'
+      htmlUrl:
+        description: Required if htmlContent is empty. URL to the body of the email (HTML)
+        type: string
+        format : url
+        example: 'https://html.domain.com'
+      subject:
+        description: Subject of the email
+        type: string
+        example: 'Thanks for your purchase !'
+      replyTo:
+        description: Email on which campaign recipients will be able to reply to
+        type: string
+        format: email
+        example: 'support@myshop.com'
+      toField:
+        description: To personalize the «To» Field. If you want to include the first name and last name of your recipient, add {FNAME} {LNAME}. These contact attributes must already exist in your Brevo account. If input parameter 'params' used please use {{contact.FNAME}} {{contact.LNAME}} for personalization
+        type: string
+        example: '{FNAME} {LNAME}'
+      attachmentUrl:
+        description: "Absolute url of the attachment (no local file). Extension allowed: xlsx, xls, ods, docx, docm, doc, csv, pdf, txt, gif, jpg, jpeg, png, tif, tiff, rtf, bmp, cgm, css, shtml, html, htm, zip, xml, ppt, pptx, tar, ez, ics, mobi, msg, pub and eps"
+        type: string
+        format: url
+        example: 'https://attachment.domain.com'
+      isActive:
+        description: Status of the template. isActive = false means template is inactive, isActive = true means template is active
+        type: boolean
+        example: true
+
+  updateCampaignStatus:
+    type: object
+    description: Status of the campaign
+    example: 'draft'
+    properties:
+      status:
+        type: string
+        description: Note:- replicateTemplate status will be available only for template type campaigns.
+        enum:
+          - suspended
+          - archive
+          - darchive
+          - sent
+          - queued
+          - cancel
+          - replicate
+          - replicateTemplate
+          - draft
+
+  createSmtpTemplate:
+    type: object
+    required:
+      - sender
+      - templateName
+      - subject
+    properties:
+      tag:
+        description: Tag of the template
+        type: string
+        example: 'OrderConfirmation'
+      sender:
+        type: object
+        description: Sender details including id or email and name (optional). Only one of either Sender's email or Sender's ID shall be passed in one request at a time. For example `{"name":"xyz", "email":"example@abc.com"}` , `{"name":"xyz", "id":123}`
+        properties:
+          name:
+            description: Name of the sender. If not passed, will be set to default
+            type: string
+            example: 'Mary from MyShop'
+          email:
+            description: Email of the sender
+            type: string
+            format: email
+            example: 'contact@myshop.com'
+          id:
+            description: Select the sender for the template on the basis of sender id. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id (instead of email).
+            type: integer
+            format: int64
+            example: 3
+      templateName:
+        description: Name of the template
+        type: string
+        example: 'Order Confirmation - EN'
+      htmlContent:
+        description: Body of the message (HTML version). The field must have more than 10 characters. REQUIRED if htmlUrl is empty
+        type: string
+        example: 'The order n°xxxxx has been confirmed. Thanks for your purchase'
+      htmlUrl:
+        description: Url which contents the body of the email message. REQUIRED if htmlContent is empty
+        type: string
+        format : url
+        example: 'https://html.domain.com'
+      subject:
+        description: Subject of the template
+        type: string
+        example: 'Thanks for your purchase !'
+      replyTo:
+        description: Email on which campaign recipients will be able to reply to
+        type: string
+        format: email
+        example: 'support@myshop.com'
+      toField:
+        description: To personalize the «To» Field. If you want to include the first name and last name of your recipient, add {FNAME} {LNAME}. These contact attributes must already exist in your Brevo account. If input parameter 'params' used please use {{contact.FNAME}} {{contact.LNAME}} for personalization
+        type: string
+        example: '{FNAME} {LNAME}'
+      attachmentUrl:
+        description: "Absolute url of the attachment (no local file). Extension allowed: xlsx, xls, ods, docx, docm, doc, csv, pdf, txt, gif, jpg, jpeg, png, tif, tiff, rtf, bmp, cgm, css, shtml, html, htm, zip, xml, ppt, pptx, tar, ez, ics, mobi, msg, pub and eps"
+        type: string
+        format: url
+        example: 'https://attachment.domain.com'
+      isActive:
+        description: Status of template. isActive = true means template is active and isActive = false means template is inactive
+        type: boolean
+        example: true
+
+  createEmailCampaign:
+    type: object
+    required:
+      - sender
+      - name
+    properties:
+      tag:
+        description: Tag of the campaign
+        type: string
+        example: 'Newsletter'
+      sender:
+        type: object
+        description: Sender details including id or email and name (optional). Only one of either Sender's email or Sender's ID shall be passed in one request at a time. For example `{"name":"xyz", "email":"example@abc.com"}` , `{"name":"xyz", "id":123}`
+        required:
+          - email
+        properties:
+          name:
+            description: Sender Name
+            type: string
+            example: 'Mary from MyShop'
+          email:
+            description: Sender email
+            type: string
+            format: email
+            example: 'newsletter@myshop.com'
+          id:
+            description: Select the sender for the campaign on the basis of sender id. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id (instead of email).
+            type: integer
+            format: int64
+            example: 3
+      name:
+        description: Name of the campaign
+        type: string
+        example: Newsletter - May 2017
+      htmlContent:
+        description: Mandatory if htmlUrl and templateId are empty. Body of the message (HTML)
+        type: string
+        example: '<!DOCTYPE html> <html> <body> <h1>Confirm you email</h1> <p>Please confirm your email address by clicking on the link below</p> </body> </html>'
+      htmlUrl:
+        description: Mandatory if htmlContent and templateId are empty. Url to the message (HTML)
+        type: string
+        format : url
+        example: 'https://html.domain.com'
+      templateId:
+        description: Mandatory if htmlContent and htmlUrl are empty. Id of the transactional email template with status 'active'. Used to copy only its content fetched from htmlContent/htmlUrl to an email campaign for RSS feature.
+        type: integer
+        format: int64
+      scheduledAt:
+        description: Sending UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. If sendAtBestTime is set to true, your campaign will be sent according to the date passed (ignoring the time part).
+        type: string
+        example: '2017-06-01T12:30:00+02:00'
+      subject:
+        description: Subject of the campaign. Mandatory if abTesting is false. Ignored if abTesting is true.
+        type: string
+        example: 'Discover the New Collection !'
+      previewText:
+        type: string
+        description : Preview text or preheader of the email campaign
+        example: Thanks for your order!
+      replyTo:
+        description: Email on which the campaign recipients will be able to reply to
+        type: string
+        format: email
+        example: 'support@myshop.com'
+      toField:
+        description: To personalize the «To» Field. If you want to include the first name and last name of your recipient, add {FNAME} {LNAME}. These contact attributes must already exist in your Brevo account. If input parameter 'params' used please use {{contact.FNAME}} {{contact.LNAME}} for personalization
+        type: string
+        example: '{FNAME} {LNAME}'
+      recipients:
+        type: object
+        description: Segment ids and List ids to include/exclude from campaign
+        properties:
+          exclusionListIds:
+            description: List ids to exclude from the campaign
+            type: array
+            items:
+              type: integer
+              format: int64
+              example: 8
+          listIds:
+            description: Mandatory if scheduledAt is not empty. List Ids to send the campaign to
+            type: array
+            items:
+              type : integer
+              format: int64
+              example: 32
+          segmentIds:
+            description: Mandatory if listIds are not used. Segment ids to send the campaign to.
+            type: array
+            items:
+              type: integer
+              format: int64
+              example: 23
+          exclusionSegmentIds:
+              description: |
+                Segment ids which have to be excluded from a campaign.
+              type: array
+              items:
+                type: integer
+                format: int64
+                example: 13
+      attachmentUrl:
+        description: "Absolute url of the attachment (no local file). Extension allowed: xlsx, xls, ods, docx, docm, doc, csv, pdf, txt, gif, jpg, jpeg, png, tif, tiff, rtf, bmp, cgm, css, shtml, html, htm, zip, xml, ppt, pptx, tar, ez, ics, mobi, msg, pub and eps"
+        type: string
+        format: url
+        example: 'https://attachment.domain.com'
+      inlineImageActivation:
+        description: Use true to embedded the images in your email. Final size of the email should be less than 4MB. Campaigns with embedded images can not be sent to more than 5000 contacts
+        type: boolean
+        default: false
+        example: true
+      mirrorActive:
+        description: Use true to enable the mirror link
+        type: boolean
+        example: true
+      footer:
+        description: Footer of the email campaign
+        type: string
+        example: '[DEFAULT_FOOTER]'
+      header:
+        description: Header of the email campaign
+        type: string
+        example: '[DEFAULT_HEADER]'
+      utmCampaign:
+        description: Customize the utm_campaign value. If this field is empty, the campaign name will be used. Only alphanumeric characters and spaces are allowed
+        type: string
+        example: 'NL_05_2017'
+      params:
+        type: object
+        description: Pass the set of attributes to customize the type classic campaign. For example, {"FNAME":"Joe", "LNAME":"Doe"}. Only available if 'type' is 'classic'. It's considered only if campaign is in New Template Language format. The New Template Language is dependent on the values of 'subject', 'htmlContent/htmlUrl', 'sender.name' & 'toField'
+        example: {"FNAME":"Joe", "LNAME":"Doe"}
+      sendAtBestTime:
+        type: boolean
+        description: Set this to true if you want to send your campaign at best time.
+        example: true
+        default: false
+      abTesting:
+        description: Status of A/B Test. abTesting = false means it is disabled, & abTesting = true means it is enabled. 'subjectA', 'subjectB', 'splitRule', 'winnerCriteria' & 'winnerDelay' will be considered when abTesting is set to true. 'subjectA' & 'subjectB' are mandatory together & 'subject' if passed is ignored. Can be set to true only if 'sendAtBestTime' is 'false'. You will be able to set up two subject lines for your campaign and send them to a random sample of your total recipients. Half of the test group will receive version A, and the other half will receive version B
+        type: boolean
+        default: false
+        example: true
+      subjectA:
+        description: Subject A of the campaign. Mandatory if abTesting = true. subjectA & subjectB should have unique value
+        type: string
+        example: 'Discover the New Collection!'
+      subjectB:
+        description: Subject B of the campaign. Mandatory if abTesting = true. subjectA & subjectB should have unique value
+        type: string
+        example: 'Want to discover the New Collection?'
+      splitRule:
+        description: Add the size of your test groups. Mandatory if abTesting = true & 'recipients' is passed. We'll send version A and B to a random sample of recipients, and then the winning version to everyone else
+        type: integer
+        format: int64
+        maximum: 50
+        minimum: 1
+        example: 50
+      winnerCriteria:
+        type: string
+        enum :
+        - open
+        - click
+        description: Choose the metrics that will determinate the winning version. Mandatory if 'splitRule' >= 1 and < 50. If splitRule = 50, 'winnerCriteria' is ignored if passed
+        example: 'open'
+      winnerDelay:
+        description: Choose the duration of the test in hours. Maximum is 7 days, pass 24*7 = 168 hours. The winning version will be sent at the end of the test. Mandatory if 'splitRule' >= 1 and < 50. If splitRule = 50, 'winnerDelay' is ignored if passed
+        type: integer
+        format: int64
+        maximum: 168
+        minimum: 1
+        example: 50
+      ipWarmupEnable:
+        description: Available for dedicated ip clients. Set this to true if you wish to warm up your ip.
+        type: boolean
+        default: false
+        example: true
+      initialQuota:
+        description: Mandatory if ipWarmupEnable is set to true. Set an initial quota greater than 1 for warming up your ip. We recommend you set a value of 3000.
+        type: integer
+        format: int64
+        example: 3000
+      increaseRate:
+        description: Mandatory if ipWarmupEnable is set to true. Set a percentage increase rate for warming up your ip. We recommend you set the increase rate to 30% per day. If you want to send the same number of emails every day, set the daily increase value to 0%.
+        type: integer
+        format: int64
+        minimum: 0
+        maximum: 100
+        example: 70
+      unsubscriptionPageId:
+        description: Enter an unsubscription page id. The page id is a 24 digit alphanumeric id that can be found in the URL when editing the page. If not entered, then the default unsubscription page will be used.
+        type: string
+        example: "62cbb7fabbe85021021aac52"
+      updateFormId:
+        description: Mandatory if templateId is used containing the {{ update_profile }} tag. Enter an update profile form id. The form id is a 24 digit alphanumeric id that can be found in the URL when editing the form. If not entered, then the default update profile form will be used.
+        type: string
+        example: "6313436b9ad40e23b371d095"
+      emailExpirationDate:
+        type: object
+        description: To reduce your carbon footprint, set an expiration date for your email. If supported, it will be automatically deleted from the recipient’s inbox, saving storage space and energy. Learn more about setting an email expiration date.
+          For reference , ``https://help.brevo.com/hc/en-us/articles/4413566705298-Create-an-email-campaign``
+        properties:
+          duration:
+            type: number
+            description: Duration of the email expiry. maximum duration can be 3600 days or 480 weeks or 120 months.
+            example: 30
+            minimum: 1
+            maximum: 3600
+          unit:
+            type: string
+            description: Date-time of the email expiration
+            example: days
+            enum:
+              - days
+              - weeks
+              - months
+  updateEmailCampaign:
+    type: object
+    properties:
+      tag:
+        description: Tag of the campaign
+        type: string
+        example: 'Newsletter'
+      sender:
+        type: object
+        description: Sender details including id or email and name (optional). Only one of either Sender's email or Sender's ID shall be passed in one request at a time. For example `{"name":"xyz", "email":"example@abc.com"}` , `{"name":"xyz", "id":123}`
+        properties:
+          name:
+            description: Sender Name from which the campaign emails are sent
+            type: string
+            example: 'Mary from MyShop'
+          email:
+            description: Sender email from which the campaign emails are sent
+            type: string
+            format: email
+            example: 'newsletter@myshop.com'
+          id:
+            description: Select the sender for the campaign on the basis of sender id. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id (instead of email).
+            type: integer
+            format: int64
+            example: 3
+      name:
+        description: Name of the campaign
+        type: string
+        example: 'Newsletter - May 2017'
+      htmlContent:
+        description: Body of the message (HTML version). If the campaign is designed using Drag & Drop editor via HTML content, then the design page will not have Drag & Drop editor access for that campaign. REQUIRED if htmlUrl is empty
+        type: string
+        example: '<!DOCTYPE html> <html> <body> <h1>Confirm you email</h1> <p>Please confirm your email address by clicking on the link below</p> </body> </html>'
+      htmlUrl:
+        description: Url which contents the body of the email message. REQUIRED if htmlContent is empty
+        type: string
+        format : url
+        example: 'https://html.domain.com'
+      scheduledAt:
+        description: UTC date-time on which the campaign has to run (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result. If sendAtBestTime is set to true, your campaign will be sent according to the date passed (ignoring the time part).
+        type: string
+        example: '2017-06-01T12:30:00+02:00'
+      subject:
+        description: Subject of the campaign
+        type: string
+        example: 'Discover the New Collection !'
+      previewText:
+        type: string
+        description : Preview text or preheader of the email campaign
+        example: Thanks for your order!
+      replyTo:
+        description: Email on which campaign recipients will be able to reply to
+        type: string
+        format: email
+        example: 'support@myshop.com'
+      toField:
+        description: To personalize the «To» Field. If you want to include the first name and last name of your recipient, add {FNAME} {LNAME}. These contact attributes must already exist in your Brevo account. If input parameter 'params' used please use {{contact.FNAME}} {{contact.LNAME}} for personalization
+        type: string
+        example: '{FNAME} {LNAME}'
+      recipients:
+        type: object
+        description: Segment ids and List ids to include/exclude from campaign
+        properties:
+          exclusionListIds:
+            description: List ids which have to be excluded from a campaign
+            type: array
+            items:
+              type: integer
+              format: int64
+              example: 8
+          listIds:
+            description: Lists Ids to send the campaign to. Campaign should only be updated with listIds if listIds were used to create it. REQUIRED if already not present in campaign and scheduledAt is not empty
+            type: array
+            items:
+              type : integer
+              format: int64
+              example: 32
+          segmentIds:
+            description: Mandatory if listIds are not used. Campaign should only be updated with segmentIds if segmentIds were used to create it. Segment ids to send the campaign to.
+            type: array
+            items:
+              type: integer
+              format: int64
+              example: 23
+          exclusionSegmentIds:
+              description: |
+                Segment ids which have to be excluded from a campaign.
+              type: array
+              items:
+                type: integer
+                format: int64
+                example: 13
+      attachmentUrl:
+        description: "Absolute url of the attachment (no local file). Extension allowed: xlsx, xls, ods, docx, docm, doc, csv, pdf, txt, gif, jpg, jpeg, png, tif, tiff, rtf, bmp, cgm, css, shtml, html, htm, zip, xml, ppt, pptx, tar, ez, ics, mobi, msg, pub and eps"
+        type: string
+        format: url
+        example: 'https://attachment.domain.com'
+      inlineImageActivation:
+        description: Status of inline image. inlineImageActivation = false means image can’t be embedded, & inlineImageActivation = true means image can be embedded, in the email. You cannot send a campaign of more than 4MB with images embedded in the email. Campaigns with the images embedded in the email must be sent to less than 5000 contacts.
+        type: boolean
+        default: false
+        example: true
+      mirrorActive:
+        description: Status of mirror links in campaign. mirrorActive = false means mirror links are deactivated, & mirrorActive = true means mirror links are activated, in the campaign
+        type: boolean
+        example: true
+      recurring:
+        description: FOR TRIGGER ONLY ! Type of trigger campaign.recurring = false means contact can receive the same Trigger campaign only once, & recurring = true means contact can receive the same Trigger campaign several times
+        type: boolean
+        default: false
+        example: false
+      footer:
+        description: Footer of the email campaign
+        type: string
+        example: '[DEFAULT_FOOTER]'
+      header:
+        description: Header of the email campaign
+        type: string
+        example: '[DEFAULT_HEADER]'
+      utmCampaign:
+        description: Customize the utm_campaign value. If this field is empty, the campaign name will be used. Only alphanumeric characters and spaces are allowed
+        type: string
+        example: 'NL_05_2017'
+      params:
+        type: object
+        description: Pass the set of attributes to customize the type 'classic' campaign. For example, {"FNAME":"Joe", "LNAME":"Doe"}. The 'params' field will get updated, only if the campaign is in New Template Language, else ignored. The New Template Language is dependent on the values of 'subject', 'htmlContent/htmlUrl', 'sender.name' & 'toField'
+        example: {"FNAME":"Joe", "LNAME":"Doe"}
+      sendAtBestTime:
+        type: boolean
+        description: Set this to true if you want to send your campaign at best time. Note:- if true, warmup ip will be disabled.
+        example: true
+      abTesting:
+        description: Status of A/B Test. abTesting = false means it is disabled, & abTesting = true means it is enabled. 'subjectA', 'subjectB', 'splitRule', 'winnerCriteria' & 'winnerDelay' will be considered if abTesting is set to true. 'subject' if passed is ignored.  Can be set to true only if 'sendAtBestTime' is 'false'. You will be able to set up two subject lines for your campaign and send them to a random sample of your total recipients. Half of the test group will receive version A, and the other half will receive version B
+        type: boolean
+        default: false
+        example: true
+      subjectA:
+        description: Subject A of the campaign. Considered if abTesting = true. subjectA & subjectB should have unique value
+        type: string
+        example: 'Discover the New Collection!'
+      subjectB:
+        description: Subject B of the campaign. Considered if abTesting = true. subjectA & subjectB should have unique value
+        type: string
+        example: 'Want to discover the New Collection?'
+      splitRule:
+        description: Add the size of your test groups. Considered if abTesting = true. We'll send version A and B to a random sample of recipients, and then the winning version to everyone else
+        type: integer
+        format: int64
+        maximum: 50
+        minimum: 1
+        example: 50
+      winnerCriteria:
+        type: string
+        enum :
+        - open
+        - click
+        description: Choose the metrics that will determinate the winning version. Considered if 'splitRule' >= 1 and < 50. If splitRule = 50, 'winnerCriteria' is ignored if passed or alreday exist in record
+        example: 'open'
+      winnerDelay:
+        description: Choose the duration of the test in hours. Maximum is 7 days, pass 24*7 = 168 hours. The winning version will be sent at the end of the test. Considered if 'splitRule' >= 1 and < 50. If splitRule = 50, 'winnerDelay' is ignored if passed or alreday exist in record
+        type: integer
+        format: int64
+        maximum: 168
+        minimum: 1
+        example: 50
+      ipWarmupEnable:
+        description: Available for dedicated ip clients. Set this to true if you wish to warm up your ip.
+        type: boolean
+        default: false
+        example: true
+      initialQuota:
+        description: Set an initial quota greater than 1 for warming up your ip. We recommend you set a value of 3000.
+        type: integer
+        format: int64
+        example: 3000
+      increaseRate:
+        description: Set a percentage increase rate for warming up your ip. We recommend you set the increase rate to 30% per day. If you want to send the same number of emails every day, set the daily increase value to 0%.
+        type: integer
+        format: int64
+        minimum: 0
+        maximum: 100
+        example: 70
+      unsubscriptionPageId:
+        description: Enter an unsubscription page id. The page id is a 24 digit alphanumeric id that can be found in the URL when editing the page.
+        type: string
+        example: "62cbb7fabbe85021021aac52"
+      updateFormId:
+        description: Mandatory if templateId is used containing the {{ update_profile }} tag. Enter an update profile form id. The form id is a 24 digit alphanumeric id that can be found in the URL when editing the form.
+        type: string
+        example: "6313436b9ad40e23b371d095"
+      emailExpirationDate:
+        type: object
+        description: To reduce your carbon footprint, set an expiration date for your email. If supported, it will be automatically deleted from the recipient’s inbox, saving storage space and energy. Learn more about setting an email expiration date.
+        properties:
+          duration:
+            type: number
+            description: Duration of the email expiry. maximum duration can be 3600 days or 480 weeks or 120 months.
+            example: 30
+            minimum: 1
+            maximum: 3600
+          unit:
+            type: string
+            description: Date-time of the email expiration
+            example: days
+            enum:
+              - days
+              - weeks
+              - months
+
+  getSharedTemplateUrl:
+    type: object
+    required:
+     - sharedUrl
+    properties:
+      sharedUrl:
+        type: string
+        format: url
+        description: A unique URL for the email campaign or transactional template. This URL can be shared with other Brevo users.
+        example: 'https://my.brevo.com/pt2YU7R5W_guXlowgumy_VX4pFsKu._zd0Gjj96x1_GMmzc1Qps5ZIpj6nx-'
+
+  abTestCampaignResult:
+    type: object
+    properties:
+      winningVersion:
+        type: string
+        description: Winning Campaign Info. pending = Campaign has been picked for sending and winning version is yet to be decided, tie = A tie happened between both the versions, notAvailable = Campaign has not yet been picked for sending.
+        enum:
+          - notAvailable
+          - pending
+          - tie
+          - A
+          - B
+        example: 'A'
+      winningCriteria:
+        type: string
+        description: Criteria choosen for winning version (Open/Click)
+        enum:
+          - Open
+          - Click
+        example: 'Open'
+      winningSubjectLine:
+        type: string
+        description: Subject Line of current winning version
+        example: 'Subject Line A'
+      openRate:
+        type: string
+        description: Open rate for current winning version
+        example: '70%'
+      clickRate:
+        type: string
+        description: Click rate for current winning version
+        example: '70%'
+      winningVersionRate:
+        type: string
+        description: Open/Click rate for the winner version
+        example: '70%'
+      statistics:
+        type: object
+        required:
+          - openers
+          - clicks
+          - unsubscribed
+          - hardBounces
+          - softBounces
+          - complaints
+        properties:
+          openers:
+            $ref: '#/definitions/abTestVersionStats'
+          clicks:
+            $ref: '#/definitions/abTestVersionStats'
+          unsubscribed:
+            $ref: '#/definitions/abTestVersionStats'
+          hardBounces:
+            $ref: '#/definitions/abTestVersionStats'
+          softBounces:
+            $ref: '#/definitions/abTestVersionStats'
+          complaints:
+            $ref: '#/definitions/abTestVersionStats'
+      clickedLinks:
+        type: object
+        required:
+          - Version A
+          - Version B
+        properties:
+          Version A:
+            $ref: '#/definitions/abTestVersionClicks'
+          Version B:
+            $ref: '#/definitions/abTestVersionClicks'
+
+  emailExportRecipients:
+    type: object
+    required:
+      - recipientsType
+    properties:
+      notifyURL:
+        description: Webhook called once the export process is finished. For reference, https://help.brevo.com/hc/en-us/articles/360007666479
+        type: string
+        format : url
+        example: 'http://requestb.in/173lyyx1'
+      recipientsType:
+        description: Type of recipients to export for a campaign
+        enum:
+          - all
+          - nonClickers
+          - nonOpeners
+          - clickers
+          - openers
+          - softBounces
+          - hardBounces
+          - unsubscribed
+        type: string
+        example: 'openers'
+
+  requestSmsRecipientExport:
+    type: object
+    required:
+      - recipientsType
+    properties:
+      notifyURL:
+        description: URL that will be called once the export process is finished. For reference, https://help.brevo.com/hc/en-us/articles/360007666479
+        type: string
+        format : url
+        example: 'http://requestb.in/173lyyx1'
+      recipientsType:
+        description: Filter the recipients based on how they interacted with the campaign
+        enum:
+          - all
+          - delivered
+          - answered
+          - softBounces
+          - hardBounces
+          - unsubscribed
+        type: string
+        example: 'answered'
+
+  sendReport:
+    type: object
+    required:
+      - email
+    properties:
+      language:
+        description: Language of email content for campaign report sending.
+        enum:
+          - fr
+          - es
+          - pt
+          - it
+          - de
+          - en
+        default: fr
+        type: string
+        example: 'en'
+      email:
+        type: object
+        required:
+          - to
+          - body
+        description: Custom attributes for the report email.
+        properties:
+          to:
+            description: Email addresses of the recipients
+            type: array
+            items:
+              type: string
+              format : email
+              description: Email address of the recipient
+              example: 'jim.suehan@example.com'
+          body:
+            description: Custom text message to be presented in the report email.
+            type: string
+            example: Please find attached the report of our last email campaign.
+
+  uploadImageToGallery:
+    type: object
+    required:
+      - imageUrl
+    properties:
+      imageUrl:
+        description: The absolute url of the image (no local file). Maximum allowed size for image is 2MB. Allowed extensions for images are - jpeg, jpg, png, bmp, gif.
+        type: string
+        example: 'https://somedomain.com/image1.jpg'
+      name:
+        description: Name of the image.
+        type: string
+        example: 'nature.jpg'
+
+  sendSmtpEmail:
+    type: object
+    properties:
+      sender:
+        description: Mandatory if `templateId` is not passed. Pass `name` (optional) and `email` OR `id` of sender from which emails will be sent. `name` will be ignored if passed along with sender `id`. For example, {"name":"Mary from MyShop", "email":"no-reply@myshop.com"} or {"id":2}
+        type: object
+        properties:
+          name:
+            description: Name of the sender from which the emails will be sent. Maximum allowed characters are 70. Applicable only when email is passed.
+            type: string
+            example: 'Mary from MyShop'
+          email:
+            description: Email of the sender from which the emails will be sent. Mandatory if sender id is not passed.
+            type: string
+            format: email
+            example: 'no-reply@myshop.com'
+          id:
+            description: Id of the sender from which the emails will be sent. In order to select a sender with specific pool of IP’s, dedicated ip users shall pass id (instead of email). Mandatory if email is not passed.
+            type: integer
+            format: int64
+            example: 2
+      to:
+        description: Mandatory if messageVersions are not passed, ignored if messageVersions are passed. List of email addresses and names (optional) of the recipients. For example, [{"name":"Jimmy", "email":"jimmy98@example.com"}, {"name":"Joe", "email":"joe@example.com"}]
+        type: array
+        items:
+          type: object
+          required:
+            - email
+          properties:
+            email:
+              description: Email address of the recipient
+              type: string
+              format: email
+              example: 'jimmy98@example.com'
+            name:
+              description: Name of the recipient. Maximum allowed characters are 70.
+              type: string
+              example: 'Jimmy'
+      bcc:
+        description: List of email addresses and names (optional) of the recipients in bcc
+        type: array
+        items:
+          type: object
+          required:
+            - email
+          properties:
+            email:
+              description: Email address of the recipient in bcc
+              type: string
+              format: email
+              example: 'helen9766@example.com'
+            name:
+              description: Name of the recipient in bcc. Maximum allowed characters are 70.
+              type: string
+              example: 'Helen'
+      cc:
+        description: List of email addresses and names (optional) of the recipients in cc
+        type: array
+        items:
+          type: object
+          required:
+            - email
+          properties:
+            email:
+              description: Email address of the recipient in cc
+              type: string
+              format: email
+              example: 'ann6533@example.com'
+            name:
+              description: Name of the recipient in cc. Maximum allowed characters are 70.
+              type: string
+              example: 'Ann'
+      htmlContent:
+        description: HTML body of the message ( Mandatory if 'templateId' is not passed, ignored if 'templateId' is passed )
+        type: string
+        example: '<!DOCTYPE html> <html> <body> <h1>Confirm you email</h1> <p>Please confirm your email address by clicking on the link below</p> </body> </html>'
+      textContent:
+        description: Plain Text body of the message ( Ignored if 'templateId' is passed )
+        type: string
+        example: 'Please confirm your email address by clicking on the link https://text.domain.com'
+      subject:
+        description: Subject of the message. Mandatory if 'templateId' is not passed
+        type: string
+        example: 'Login Email confirmation'
+      replyTo:
+        description: Email (required), along with name (optional), on which transactional mail recipients will be able to reply back. For example, {"email":"ann6533@example.com", "name":"Ann"}.
+        type: object
+        required:
+           - email
+        properties:
+            email:
+              description: Email address in reply to
+              type: string
+              format: email
+              example: 'ann6533@example.com'
+            name:
+              description: Name in reply to. Maximum allowed characters are 70.
+              type: string
+              example: 'Ann'
+      attachment:
+        description: "Pass the absolute URL (no local file) or the base64 content of the attachment along with the attachment name (Mandatory if attachment content is passed). For example, `[{\"url\":\"https://attachment.domain.com/myAttachmentFromUrl.jpg\", \"name\":\"myAttachmentFromUrl.jpg\"}, {\"content\":\"base64 example content\", \"name\":\"myAttachmentFromBase64.jpg\"}]`. Allowed extensions for attachment file: xlsx, xls, ods, docx, docm, doc, csv, pdf, txt, gif, jpg, jpeg, png, tif, tiff, rtf, bmp, cgm, css, shtml, html, htm, zip, xml, ppt, pptx, tar, ez, ics, mobi, msg, pub, eps, odt, mp3, m4a, m4v, wma, ogg, flac, wav, aif, aifc, aiff, mp4, mov, avi, mkv, mpeg, mpg, wmv, pkpass and xlsm ( If 'templateId' is passed and is in New Template Language format then both attachment url and content are accepted. If template is in Old template Language format, then 'attachment' is ignored )"
+        type: array
+        items:
+          type: object
+          properties:
+            url:
+              description: Absolute url of the attachment (no local file).
+              type: string
+              format: url
+              example: 'https://attachment.domain.com/myAttachmentFromUrl.jpg'
+            content:
+              description: Base64 encoded chunk data of the attachment generated on the fly
+              type: string
+              format: byte
+              example: 'b3JkZXIucGRm'
+            name:
+              description: Required if content is passed. Name of the attachment
+              type: string
+              example: 'myAttachment.png'
+      headers:
+        type: object
+        description: Pass the set of custom headers (not the standard headers) that shall be sent along the mail headers in the original email. 'sender.ip' header can be set (only for dedicated ip users) to mention the IP to be used for sending transactional emails. Headers are allowed in `This-Case-Only` (i.e. words separated by hyphen with first letter of each word in capital letter), they will be converted to such case styling if not in this format in the request payload. For example, `{"sender.ip":"1.2.3.4", "X-Mailin-custom":"some_custom_header", "idempotencyKey":"abc-123"}`.
+        example: {"sender.ip":"1.2.3.4", "X-Mailin-custom":"some_custom_header", "idempotencyKey":"abc-123"}
+      templateId:
+        description: Id of the template.
+        type: integer
+        format: int64
+        example: 2
+      params:
+        type: object
+        description: Pass the set of attributes to customize the template. For example, {"FNAME":"Joe", "LNAME":"Doe"}. It's considered only if template is in New Template Language format.
+        example: {"FNAME":"Joe", "LNAME":"Doe"}
+      messageVersions:
+        type: array
+        description: You can customize and send out multiple versions of a mail. templateId can be customized only if global parameter contains templateId. htmlContent and textContent can be customized only if any of the two, htmlContent or textContent, is present in global parameters. Some global parameters such as **to(mandatory), bcc, cc, replyTo, subject** can also be customized specific to each version. Total number of recipients in one API request must not exceed 2000. However, you can still pass upto 99 recipients maximum in one message version. The size of individual params in all the messageVersions shall not exceed 100 KB limit and that of cumulative params shall not exceed 1000 KB. You can follow this **step-by-step guide** on how to use **messageVersions** to batch send emails - https://developers.brevo.com/docs/batch-send-transactional-emails
+        items:
+          type: object
+          required:
+          - to
+          properties:
+            to:
+              type: array
+              description: List of email addresses and names (_optional_) of the recipients. For example, [{"name":"Jimmy", "email":"jimmy98@example.com"}, {"name":"Joe", "email":"joe@example.com"}]
+              items:
+                required:
+                - email
+                type: object
+                properties:
+                  email:
+                    type: string
+                    description: Email address of the recipient
+                    format: email
+                    example: jimmy98@example.com
+                  name:
+                    type: string
+                    description: Name of the recipient. **Maximum allowed characters are 70**.
+                    example: Jimmy
+            params:
+              type: object
+              additionalProperties: {}
+              description: Pass the set of attributes to customize the template. For example, {"FNAME":"Joe", "LNAME":"Doe"}. It's considered only if template is in New Template Language format.
+              example:
+                FNAME: Joe
+                LNAME: Doe
+            bcc:
+              type: array
+              description: List of email addresses and names (optional) of the recipients in bcc
+              items:
+                required:
+                - email
+                type: object
+                properties:
+                  email:
+                    type: string
+                    description: Email address of the recipient in bcc
+                    format: email
+                    example: helen9766@example.com
+                  name:
+                    type: string
+                    description: Name of the recipient in bcc. Maximum allowed characters are 70.
+                    example: Helen
+            cc:
+              type: array
+              description: List of email addresses and names (optional) of the recipients in cc
+              items:
+                required:
+                - email
+                type: object
+                properties:
+                  email:
+                    type: string
+                    description: Email address of the recipient in cc
+                    format: email
+                    example: ann6533@example.com
+                  name:
+                    type: string
+                    description: Name of the recipient in cc. Maximum allowed characters are 70.
+                    example: Ann
+            replyTo:
+              required:
+              - email
+              type: object
+              properties:
+                email:
+                  type: string
+                  description: Email address in reply to
+                  format: email
+                  example: ann6533@example.com
+                name:
+                  type: string
+                  description: Name in reply to. Maximum allowed characters are 70.
+                  example: Ann
+              description: Email (required), along with name (optional), on which transactional mail recipients will be able to reply back. For example, {"email":"ann6533@example.com", "name":"Ann"}
+            subject:
+              type: string
+              description: |
+                Custom subject specific to message version
+              example: Login Email confirmation
+            htmlContent:
+              type: string
+              description: |
+                HTML body of the message. **Mandatory if 'templateId' is not passed, ignored if 'templateId' is passed**
+              example: <!DOCTYPE html> <html> <body> <h1>Confirm you email</h1> <p>Please
+                confirm your email address by clicking on the link below</p> </body> </html>
+            textContent:
+              type: string
+              description: |
+                Plain Text body of the message. **Ignored if 'templateId' is passed**
+              example: Please confirm your email address by clicking on the link https://text.domain.com
+            headers:
+              type: object
+              description: Pass the set of custom headers (not the standard headers) that shall be sent along the mail headers in the original email. 'sender.ip' header can be set (only for dedicated ip users) to mention the IP to be used for sending transactional emails. Headers are allowed in `This-Case-Only` (i.e. words separated by hyphen with first letter of each word in capital letter), they will be converted to such case styling if not in this format in the request payload. For example, `{"sender.ip":"1.2.3.4", "X-Mailin-custom":"some_custom_header", "idempotencyKey":"abc-123"}`.
+              example: {"X-Mailin-custom":"some_custom_header"}    
+      tags:
+        description: Tag your emails to find them more easily
+        type: array
+        items:
+          type: string
+          example: 'tag1'
+      scheduledAt:
+          type: string
+          description: UTC date-time on which the email has to schedule (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for scheduling. There can be an expected delay of +5 minutes in scheduled email delivery.
+          format: date-time
+          example: '2022-04-05T12:30:00+02:00'
+      batchId:
+        type: string
+        description: Valid UUIDv4 batch id to identify the scheduled batches transactional email. If not passed we will create a valid UUIDv4 batch id at our end.
+        example: '5c6cfa04-eed9-42c2-8b5c-6d470d978e9d'
+      preheader:
+        type: string
+        description: |
+          A short summary that appears next to the subject line in the recipient’s inbox. This preview text gives recipients a quick idea of what the email is about before they open it.
+  fetchTemplatePreview:
+    required:
+    - templateId
+    type: object
+    properties:
+      templateId:
+        description: Id of the template.
+        type: integer
+        example: 2
+      email:
+        description: Email of the contact.(Required if params not provided)
+        type: string
+        format: email
+        example: 'john.doe@example.com'
+      params:
+        type: object
+        description: Key-value pairs of dynamic parameters for template rendering.(Required if email not provided) For example, {"Firstname":"John", "Lastname":"Doe"}.
+        example: {"Firstname":"John", "Lastname":"Doe"}
+
+  deleteHardbounces:
+    type: object
+    properties:
+      startDate:
+        description: Starting date (YYYY-MM-DD) of the time period for deletion. The hardbounces occurred after this date will be deleted. Must be less than or equal to the endDate
+        type: string
+        example: '2016-12-31'
+      endDate:
+        description: Ending date (YYYY-MM-DD) of the time period for deletion. The hardbounces until this date will be deleted. Must be greater than or equal to the startDate
+        type: string
+        example: '2017-01-31'
+      contactEmail:
+        description: Target a specific email address
+        type: string
+        format: email
+        example: 'alex76@example.com'
+
+  createWebhook:
+    type: object
+    required:
+      - url
+      - events
+    properties:
+      url:
+        description: URL of the webhook
+        type: string
+        format: url
+        example: 'http://requestb.in/173lyyx1'
+      description:
+        description: Description of the webhook
+        type: string
+        example : 'Webhook triggered on unsubscription'
+      events:
+        description: |
+            - Events triggering the webhook. Possible values for **Transactional** type webhook:
+            #### `sent` OR `request`, `delivered`, `hardBounce`, `softBounce`, `blocked`, `spam`, `invalid`, `deferred`, `click`, `opened`, `uniqueOpened` and `unsubscribed`
+            - Possible values for **Marketing** type webhook:
+            #### `spam`, `opened`, `click`, `hardBounce`, `softBounce`, `unsubscribed`, `listAddition` & `delivered`
+            - Possible values for **Inbound** type webhook:
+            #### `inboundEmailProcessed`
+            - Possible values for type **Transactional** and channel **SMS**
+            #### `accepted`,`delivered`,`softBounce`,`hardBounce`,`unsubscribe`,`reply`, `subscribe`,`sent`,`blacklisted`,`skip`
+            - Possible values for type **Marketing**  channel **SMS**
+            #### `sent`,`delivered`,`softBounce`,`hardBounce`,`unsubscribe`,`reply`, `subscribe`,`skip`
+        type: array
+        items:
+          type: string
+          enum:
+            - sent
+            - hardBounce
+            - softBounce
+            - blocked
+            - spam
+            - delivered
+            - request
+            - click
+            - invalid
+            - deferred
+            - opened
+            - uniqueOpened
+            - unsubscribed
+            - listAddition
+            - contactUpdated
+            - contactDeleted
+            - inboundEmailProcessed
+          example: 'unsubscribed'
+      type:
+        description: Type of the webhook
+        enum:
+          - transactional
+          - marketing
+          - inbound
+        default: transactional
+        type: string
+        example: 'marketing'
+      channel:
+          type: string
+          description: channel of webhook
+          example: sms
+          default: email
+          enum:
+          - sms
+          - email
+      domain:
+          type: string
+          description: Inbound domain of webhook, required in case of event type `inbound`
+          example: example.com
+      batched:
+        description: To send batched webhooks
+        type: boolean
+        example: true
+      auth:
+          description: Add authentication on webhook url
+          type: object
+          required:
+            - type
+            - token
+          properties:
+            type:
+              description: Type of authentication
+              type: string
+              example: bearer
+            token:
+              description: Webhook authentication token
+              type: string
+              example: test-auth-token1234
+          example:
+            type: bearer
+            token: test-auth-token1234
+    headers:
+        description: |
+          The headers sent with the request to the webhook. Header format: "headers": [{ "key": "cf-secret","value": "test-header-value"}]
+        type: array
+        items:
+          type: object
+          required:
+            - key
+            - value
+          properties:
+            key:
+              type: string
+              description: Header key name
+              example: cf-secret
+            value:
+              type: string
+              description: Header value
+              example: test-header-value
+          additionalProperties: false
+        example:
+          - key: cf-secret
+            value: test-header-value
+          - key: x-api-key
+            value: abc123
+
+  updateWebhook:
+    type: object
+    properties:
+      url:
+        description: URL of the webhook
+        type: string
+        format: url
+        example: 'http://requestb.in/173lyyx1'
+      description:
+        description: Description of the webhook
+        type: string
+        example : 'Webhook triggered on contact hardbounce'
+      events:
+        description: |
+            - Events triggering the webhook. Possible values for **Transactional** type webhook:
+            #### `sent` OR `request`, `delivered`, `hardBounce`, `softBounce`, `blocked`, `spam`, `invalid`, `deferred`, `click`, `opened`, `uniqueOpened` and `unsubscribed`
+            - Possible values for **Marketing** type webhook:
+            #### `spam`, `opened`, `click`, `hardBounce`, `softBounce`, `unsubscribed`, `listAddition` & `delivered`
+            - Possible values for **Inbound** type webhook:
+            #### `inboundEmailProcessed`
+        type: array
+        items:
+          type: string
+          enum:
+            - sent
+            - hardBounce
+            - softBounce
+            - blocked
+            - spam
+            - delivered
+            - request
+            - click
+            - invalid
+            - deferred
+            - opened
+            - uniqueOpened
+            - unsubscribed
+            - listAddition
+            - contactUpdated
+            - contactDeleted
+            - inboundEmailProcessed
+          example: 'hardBounce'
+      domain:
+          type: string
+          description: Inbound domain of webhook, used in case of event type `inbound`
+          example: example.com
+      batched:
+        description: To send batched webhooks
+        type: boolean
+        example: true
+      auth:
+          description: Add authentication on webhook url
+          type: object
+          required:
+            - type
+            - token
+          properties:
+            type:
+              description: Type of authentication
+              type: string
+              example: bearer
+            token:
+              description: Webhook authentication token
+              type: string
+              example: test-auth-token1234
+          example:
+            type: bearer
+            token: test-auth-token1234
+      headers:
+          description: |
+            The headers sent with the request to the webhook. Header format: "headers": [{ "key": "cf-secret","value": "test-header-value"}]
+          type: array
+          items:
+            type: object
+            required:
+              - key
+              - value
+            properties:
+              key:
+                type: string
+                description: Header key name
+                example: cf-secret
+              value:
+                type: string
+                description: Header value
+                example: test-header-value
+            additionalProperties: false
+          example:
+            - key: cf-secret
+              value: test-header-value
+            - key: x-api-key
+              value: abc123
+
+  createDoiContact:
+    type: object
+    required:
+      - email
+      - includeListIds
+      - templateId
+      - redirectionUrl
+    properties:
+      email:
+        description: Email address where the confirmation email will be sent. This email address will be the identifier for all other contact attributes.
+        type: string
+        format: email
+        example: 'elly@example.com'
+      attributes:
+        additionalProperties : {}
+        description: Pass the set of attributes and their values. These attributes must be present in your Brevo account. For eg. {'FNAME':'Elly', 'LNAME':'Roger', 'COUNTRIES':['India','China']}
+        type: object
+        example: {'FNAME':'Elly', 'LNAME':'Roger' , 'COUNTRIES':['India','China']}
+      includeListIds:
+        description: Lists under user account where contact should be added
+        type: array
+        items:
+          type: integer
+          format: int64
+          description: Id of the list
+          example: 36
+      excludeListIds:
+        description: Lists under user account where contact should not be added
+        type: array
+        items:
+          type: integer
+          format: int64
+          description: Id of the list
+          example: 36
+      templateId:
+        description: Id of the Double opt-in (DOI) template
+        type: integer
+        format: int64
+        example: 2
+      redirectionUrl:
+        description: URL of the web page that user will be redirected to after clicking on the double opt in URL. When editing your DOI template you can reference this URL by using the tag {{ params.DOIurl }}.
+        type: string
+        format: url
+        example: 'http://requestb.in/173lyyx1'
+
+  createContact:
+    type: object
+    properties:
+      email:
+        description: Email address of the user. **Mandatory if "ext_id"  & "SMS" field is not passed.**
+        type: string
+        format: email
+        example: 'elly@example.com'
+      ext_id:
+        description: Pass your own Id to create a contact.
+        type: string
+        example: 'externalId'
+      attributes:
+        additionalProperties : {}
+        description: Pass the set of attributes and their values. These attributes must be present in your Brevo account. For eg. {'FNAME':'Elly', 'LNAME':'Roger', 'COUNTRIES':['India','China']}
+        type: object
+        example: {"FNAME":"Elly", "LNAME":"Roger", "COUNTRIES":["India","China"]}
+      emailBlacklisted:
+        description: Set this field to blacklist the contact for emails (emailBlacklisted = true)
+        type: boolean
+        example: false
+      smsBlacklisted:
+        description: Set this field to blacklist the contact for SMS (smsBlacklisted = true)
+        type: boolean
+        example: false
+      listIds:
+        description: Ids of the lists to add the contact to
+        type: array
+        items:
+          type: integer
+          format: int64
+          description: Id of the list to add the contact to
+          example: 36
+      updateEnabled:
+        description: Facilitate to update the existing contact in the same request (updateEnabled = true)
+        type: boolean
+        default: false
+        example: false
+      smtpBlacklistSender:
+        description: transactional email forbidden sender for contact. Use only for email Contact ( only available if updateEnabled = true )
+        type: array
+        items:
+          type: string
+          format: email
+
+  updateContact:
+    type: object
+    properties:
+      attributes:
+        additionalProperties : {}
+        type: object
+        description: Pass the set of attributes to be updated. These attributes must be present in your account. Values that don't match the attribute type (e.g. text or string in a date attribute) will be ignored.To update existing email address of a contact with the new one please pass EMAIL in attributes. For example, `{ "EMAIL":"newemail@domain.com", "FNAME":"Ellie", "LNAME":"Roger", "COUNTRIES":["India","China"]}`. The attribute's parameter should be passed in capital letter while updating a contact. Keep in mind transactional attributes can be updated the same way as normal attributes. Mobile Number in "SMS" field should be passed with proper country code. For example {"SMS":"+91xxxxxxxxxx"} or {"SMS":"0091xxxxxxxxxx"}
+        example: {"EMAIL":"newemail@domain.com", "FNAME":"Ellie", "LNAME":"Roger", "COUNTRIES":["India","China"]}
+      ext_id:
+          description: Pass your own Id to update ext_id of a contact.
+          type: string
+          example: 'updateExternalId'
+      emailBlacklisted:
+        description: Set/unset this field to blacklist/allow the contact for emails (emailBlacklisted = true)
+        type: boolean
+        example: false
+      smsBlacklisted:
+        description: Set/unset this field to blacklist/allow the contact for SMS (smsBlacklisted = true)
+        type: boolean
+        example: true
+      listIds:
+        description: Ids of the lists to add the contact to
+        type: array
+        items:
+          type: integer
+          format: int64
+          description: Id of the list to add the contact to
+          example: 65
+      unlinkListIds:
+        description: Ids of the lists to remove the contact from
+        type: array
+        items:
+          type: integer
+          format: int64
+          description: Id of the list to remove the contact from
+          example: 36
+      smtpBlacklistSender:
+        description: transactional email forbidden sender for contact. Use only for email Contact
+        type: array
+        items:
+          type: string
+          format: email
+
+  updateBatchContacts:
+    type: object
+    properties:
+      contacts:
+        type: array
+        description: List of contacts to be updated
+        items:
+          type: object
+          properties:
+            email:
+              type: string
+              description: Email address of the user to be updated (For each operation only pass one of the supported contact identifiers. Email, id or sms)
+              format: email
+              example: elly@example.com
+            id:
+              type: integer
+              description: id of the user to be updated (For each operation only pass one of the supported contact identifiers. Email, id or sms)
+              format: int64
+              example: 31
+            sms:
+              type: string
+              description: SMS of the user to be updated (For each operation only pass one of the supported contact identifiers. Email, id or sms)
+              example: +91xxxxxxxxxx
+            ext_id:
+                description: Pass your own Id to update ext_id of a contact.
+                type: string
+                example: 'UpdateExternalId'
+            attributes:
+              type: object
+              additionalProperties: {}
+              description: |
+                Pass the set of attributes to be updated. **These attributes must be present in your account**. To update existing email address of a contact with the new one please pass EMAIL in attribtes. For example, **{ "EMAIL":"newemail@domain.com", "FNAME":"Ellie", "LNAME":"Roger"}**.
+                Keep in mind transactional attributes can be updated the same way as normal attributes. Mobile Number in **SMS** field should be passed with proper country code. For example: **{"SMS":"+91xxxxxxxxxx"} or {"SMS":"0091xxxxxxxxxx"}**
+              example:
+                EMAIL: newemail@domain.com
+                FNAME: Ellie
+                LNAME: Roger
+            emailBlacklisted:
+              type: boolean
+              description: Set/unset this field to blacklist/allow the contact for emails
+                (emailBlacklisted = true)
+              example: false
+            smsBlacklisted:
+              type: boolean
+              description: Set/unset this field to blacklist/allow the contact for SMS
+                (smsBlacklisted = true)
+              example: true
+            listIds:
+              type: array
+              description: Ids of the lists to add the contact to
+              items:
+                type: integer
+                description: Id of the list to add the contact to
+                format: int64
+                example: 65
+            unlinkListIds:
+              type: array
+              description: Ids of the lists to remove the contact from
+              items:
+                type: integer
+                description: Id of the list to remove the contact from
+                format: int64
+                example: 36
+            smtpBlacklistSender:
+              type: array
+              description: transactional email forbidden sender for contact. Use only
+                for email Contact
+              items:
+                type: string
+                format: email
+
+  createAttribute:
+    type: object
+    properties:
+      value:
+        description: Value of the attribute. Use only if the attribute's category is 'calculated' or 'global'
+        type: string
+        example: 'COUNT[BLACKLISTED,BLACKLISTED,<,NOW()]'
+      isRecurring:
+        type: boolean
+        description: Type of the attribute. Use only if the attribute's category is 'calculated' or 'global'
+        example: true
+      enumeration:
+        description: List of values and labels that the attribute can take. Use only if the attribute's category is "category". None of the category options can exceed max 200 characters. For example, [{"value":1, "label":"male"}, {"value":2, "label":"female"}]
+        type: array
+        items:
+          type: object
+          required:
+            - value
+            - label
+          properties:
+            value:
+              description: Id of the value
+              type: integer
+              example: 1
+            label:
+              description: Label of the value
+              type: string
+              example: 'Women'
+      multiCategoryOptions:
+        type: array
+        description: |
+          List of options you want to add for multiple-choice attribute. **Use only if the attribute's category is "normal" and attribute's type is "multiple-choice". None of the multicategory options can exceed max 200 characters.** For example:
+          **["USA","INDIA"]**
+        items:
+          type: string
+      type:
+        description : Type of the attribute. Use only if the attribute's category is 'normal', 'category' or 'transactional' ( type 'user' and 'multiple-choice' is only available if the category is 'normal' attribute, type 'id' is only available if the category is 'transactional' attribute & type 'category' is only available if the category is 'category' attribute )
+        type: string
+        enum:
+         - text
+         - date
+         - float
+         - boolean
+         - id
+         - category
+         - multiple-choice
+        example: 'text'
+
+  updateAttribute:
+    type: object
+    properties:
+      value:
+        description: Value of the attribute to update. Use only if the attribute's category is 'calculated' or 'global'
+        type: string
+        example: 'COUNT[BLACKLISTED,BLACKLISTED,<,NOW()]'
+      enumeration:
+        description: List of the values and labels that the attribute can take. Use only if the attribute's category is "category". None of the category options can exceed max 200 characters. For example, [{"value":1, "label":"male"}, {"value":2, "label":"female"}]
+        type: array
+        items:
+          type: object
+          required:
+            - value
+            - label
+          properties:
+            value:
+              description: Id of the value
+              type: integer
+              example: 1
+            label:
+              description: Label of the value
+              type: string
+              example: 'Men'
+      multiCategoryOptions:
+        type: array
+        description: |
+          Use this option to add multiple-choice attributes options only if the attribute's category is "normal". **This option is specifically designed for updating multiple-choice attributes. None of the multicategory options can exceed max 200 characters **. For example:
+          **["USA","INDIA"]**
+        items:
+          type: string
+  createList:
+    type: object
+    required:
+      - name
+      - folderId
+    properties:
+      name:
+        description: Name of the list
+        type: string
+        example: 'Magento Customer - ES'
+      folderId:
+        description: Id of the parent folder in which this list is to be created
+        type: integer
+        format: int64
+        example: 2
+  ssoTokenRequestCorporate:
+    type: object
+    required:
+      - email
+    properties:
+      email:
+        description: User email of sub-account organization
+        type: string
+        example: vipin+subaccount@brevo.com
+  ssoTokenRequest:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        description: Id of the sub-account organization
+        type: integer
+        format: int64
+        example: 2333323
+      email:
+        description: User email of sub-account organization
+        type: string
+        example: vipin+subaccount@brevo.com
+      target:
+        description: |
+          Set target after login success
+          * automation - Redirect to Automation after login
+          * email_campaign - Redirect to Email Campaign after login
+          * contacts - Redirect to Contacts after login
+          * landing_pages - Redirect to Landing Pages after login
+          * email_transactional - Redirect to Email Transactional after login
+          * senders - Redirect to Contacts after login
+          * sms_campaign - Redirect to Sms Campaign after login
+          * sms_transactional - Redirect to Sms Transactional after login
+        type: string
+        enum:
+          - automation
+          - email_campaign
+          - contacts
+          - landing_pages
+          - email_transactional
+          - senders
+          - sms_campaign
+          - sms_transactional
+        example: contacts
+      url:
+        type: string
+        description: Set the full target URL after login success. The user will land directly on this target URL after login
+        example: https://app.brevo.com/senders/domain/list
+
+  createApiKeyRequest:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        description: Id of the sub-account organization
+        type: integer
+        format: int64
+        example: 2333323
+      name:
+        description: Name of the API key
+        type: string
+        example: My Api Key
+
+  updateList:
+    type: object
+    properties:
+      name:
+        description: Name of the list. Either of the two parameters (name, folderId) can be updated at a time.
+        type: string
+        example : 'Magento Customer - ES'
+      folderId:
+        description: Id of the folder in which the list is to be moved. Either of the two parameters (name, folderId) can be updated at a time.
+        type: integer
+        format: int64
+        example: 2
+
+  requestContactExport:
+    type: object
+    required:
+    - customContactFilter
+    properties:
+      exportAttributes:
+        description: List of all the attributes that you want to export. These attributes must be present in your contact database. It is required if exportMandatoryAttributes is set false. For example, ['fname', 'lname', 'email'].
+        type: array
+        items:
+          type: string
+          example: 'NAME'
+      customContactFilter:
+        description: Set the filter for the contacts to be exported.
+        type: object
+        properties:
+          actionForContacts:
+            description: >
+              Mandatory if neither actionForEmailCampaigns nor actionForSmsCampaigns is passed. This will export the contacts on the basis of provided action applied on contacts as per the list id.
+              * allContacts - Fetch the list of all contacts for a particular list.
+              * subscribed & unsubscribed - Fetch the list of subscribed / unsubscribed (blacklisted via any means) contacts for a particular list.
+              * unsubscribedPerList - Fetch the list of contacts that are unsubscribed from a particular list only.
+            type: string
+            enum:
+              - allContacts
+              - subscribed
+              - unsubscribed
+              - unsubscribedPerList
+          actionForEmailCampaigns:
+            description: >
+              Mandatory if neither actionForContacts nor actionForSmsCampaigns is passed. This will export the contacts on the basis of provided action applied on email campaigns.
+              * openers & nonOpeners - emailCampaignId is mandatory. Fetch the list of readers / non-readers for a particular email campaign.
+              * clickers & nonClickers - emailCampaignId is mandatory. Fetch the list of clickers / non-clickers for a particular email campaign.
+              * unsubscribed - emailCampaignId is mandatory. Fetch the list of all unsubscribed (blacklisted via any means) contacts for a particular email campaign.
+              * hardBounces & softBounces - emailCampaignId is optional. Fetch the list of hard bounces / soft bounces for a particular / all email campaign(s).
+            type: string
+            enum:
+              - openers
+              - nonOpeners
+              - clickers
+              - nonClickers
+              - unsubscribed
+              - hardBounces
+              - softBounces
+          actionForSmsCampaigns:
+            description: >
+              Mandatory if neither actionForContacts nor actionForEmailCampaigns is passed. This will export the contacts on the basis of provided action applied on sms campaigns.
+              * unsubscribed - Fetch the list of all unsubscribed (blacklisted via any means) contacts for all / particular sms campaigns.
+              * hardBounces & softBounces - Fetch the list of hard bounces / soft bounces for all / particular sms campaigns.
+            type: string
+            enum:
+              - hardBounces
+              - softBounces
+              - unsubscribed
+          listId:
+            description: ID of the list. This is mandatory if actionForContacts is specified and segmentId is not provided. Either segmentId or listId must be included.
+            type: integer
+            format: int64
+            example: 2
+          segmentId:
+            type: integer
+            description: |
+              ID of the segment. This is mandatory if actionForContacts is specified and listId is not provided. Either segmentId or listId must be included.
+            format: int64
+            example: 2
+          emailCampaignId:
+            description: Considered only if actionForEmailCampaigns is passed, ignored otherwise. Mandatory if action is one of the following - openers, nonOpeners, clickers, nonClickers, unsubscribed. The id of the email campaign for which the corresponding action shall be applied in the filter.
+            type: integer
+            format: int64
+            example: 12
+          smsCampaignId:
+            description: Considered only if actionForSmsCampaigns is passed, ignored otherwise. The id of sms campaign for which the corresponding action shall be applied in the filter.
+            type: integer
+            format: int64
+            example: 12
+      notifyUrl:
+        description: Webhook that will be called once the export process is finished. For reference, https://help.brevo.com/hc/en-us/articles/360007666479
+        type: string
+        format: url
+        example: 'http://requestb.in/173lyyx1'
+      disableNotification:
+        type: boolean
+        description: To avoid generating the email notification upon contact export, pass **true**
+        example: false
+        default: false
+      exportMandatoryAttributes:
+        type: boolean
+        description: To export mandatory attributes like EMAIL, ADDED_TIME, MODIFIED_TIME
+        example: false
+        default: true
+      exportSubscriptionStatus:
+        description: Export subscription status of contacts for email & sms marketting. Pass email_marketing to obtain the marketing email subscription status & sms_marketing to retrieve the marketing SMS status of the contact.
+        type: array
+        items:
+          type: string
+          example: 'email_marketing'
+      exportMetadata:
+        description: Export metadata of contacts such as _listIds, ADDED_TIME, MODIFIED_TIME.
+        type: array
+        items:
+          type: string
+          example: _listIds
+      exportDateInUTC:
+        type: boolean
+        description: Specifies whether the date fields createdAt, modifiedAt in the exported data should be returned in UTC format.
+        example: true
+        default: false
+
+  requestContactImport:
+    type: object
+    properties:
+      fileUrl:
+        description: "Mandatory if fileBody or jsonBody is not defined. URL of the file to be imported (no local file). Possible file formats: .txt, .csv, .json"
+        type: string
+        format: url
+        example: 'https://importfile.domain.com'
+      fileBody:
+        description: Mandatory if fileUrl and jsonBody is not defined. CSV content to be imported. Use semicolon to separate multiple attributes. Maximum allowed file body size is 10MB . However we recommend a safe limit of around 8 MB to avoid the issues caused due to increase of file body size while parsing. Please use fileUrl instead to import bigger files.
+        type: string
+        example: "NAME;SURNAME;EMAIL\nSmith;John;john.smith@example.com\nRoger;Ellie;ellie36@example.com"
+      jsonBody:
+        type: array
+        description: |
+          **Mandatory if fileUrl and fileBody is not defined.** JSON content to be imported. **Maximum allowed json body size is 10MB** . However we recommend a safe limit of around 8 MB to avoid the issues caused due to increase of json body size while parsing. Please use fileUrl instead to import bigger files.
+        items:
+          type: object
+          properties:
+              email:
+                type: string
+              attributes:
+                type: object
+                additionalProperties: true
+                description: List of attributes to be imported
+          example: {"email":"ndicky0@ocn.ne.jp","attributes":{"LNAME":"Noemi","FNAME":"Dicky","COUNTRY": "DE","BIRTHDAY": "11/02/1989","PREFERED_COLOR": "BLACK","WHATSAPP": "33689965433","LANDLINE_NUMBER": "33689965433", "SMS": "33689965433"}}
+      listIds:
+        description: Mandatory if newList is not defined. Ids of the lists in which the contacts shall be imported. For example, [2, 4, 7].
+        type: array
+        items:
+          type: integer
+          format: int64
+          description: List Id in which the contacts shall be imported
+          example: 76
+      notifyUrl:
+        description: URL that will be called once the import process is finished. For reference, https://help.brevo.com/hc/en-us/articles/360007666479
+        type: string
+        format: url
+        example: 'http://requestb.in/173lyyx1'
+      newList:
+        type: object
+        description: To create a new list and import the contacts into it, pass the listName and an optional folderId.
+        properties:
+          listName:
+            description:  List with listName will be created first and users will be imported in it (Mandatory if listIds is empty).
+            type: string
+            example: 'ContactImport - 2017-05'
+          folderId:
+            description: Id of the folder where this new list shall be created (Mandatory if listName is not empty).
+            type: integer
+            format: int64
+            example: 2
+      emailBlacklist:
+        description: To blacklist all the contacts for email
+        type: boolean
+        default: false
+        example: false
+      disableNotification:
+        type: boolean
+        description: To disable email notification
+        example: false
+        default: false
+      smsBlacklist:
+        description: To blacklist all the contacts for sms
+        type: boolean
+        default: false
+        example: false
+      updateExistingContacts:
+        description: To facilitate the choice to update the existing contacts
+        type: boolean
+        default: true
+        example: true
+      emptyContactsAttributes:
+        description: To facilitate the choice to erase any attribute of the existing contacts with empty value. emptyContactsAttributes = true means the empty fields in your import will erase any attribute that currently contain data in Brevo, & emptyContactsAttributes = false means the empty fields will not affect your existing data ( only available if `updateExistingContacts` set to true )
+        type: boolean
+        default: false
+        example: true
+
+  createSmsCampaign:
+    type: object
+    required:
+      - name
+      - sender
+      - content
+    properties:
+      name:
+        description: Name of the campaign
+        type: string
+        example: 'Spring Promo Code'
+      sender:
+        description: Name of the sender. **The number of characters is limited to 11 for alphanumeric characters and 15 for numeric characters**
+        type: string
+        maxLength: 15
+        example: MyShop
+      content:
+        description: Content of the message. The maximum characters used per SMS is 160, if used more than that, it will be counted as more than one SMS
+        type: string
+        example: 'Get a discount by visiting our NY store and saying : Happy Spring !'
+      recipients:
+        type: object
+        required:
+          - listIds
+        properties:
+          listIds:
+            description: Lists Ids to send the campaign to. REQUIRED if scheduledAt is not empty
+            type: array
+            items:
+              type: integer
+              format: int64
+              description: List Id to send the campaign to
+              example: 54
+          exclusionListIds:
+            description: List ids which have to be excluded from a campaign
+            type: array
+            items:
+              type: integer
+              format: int64
+              description: List Id to exclude from the campaign
+              example: 15
+      scheduledAt:
+        description: UTC date-time on which the campaign has to run (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
+        type: string
+        example: '2017-05-05T12:30:00+02:00'
+      unicodeEnabled:
+          type: boolean
+          description: Format of the message. It indicates whether the content should be treated as unicode or not.
+          example: true
+          default: false
+      organisationPrefix:
+          description : A recognizable prefix will ensure your audience knows who you are. Recommended by U.S. carriers. This will be added as your Brand Name before the message content. **Prefer verifying maximum length of 160 characters including this prefix in message content to avoid multiple sending of same sms.**
+          type: string
+          example: MyCompany
+      unsubscribeInstruction:
+          description : Instructions to unsubscribe from future communications. Recommended by U.S. carriers. Must include **STOP** keyword. This will be added as instructions after the end of message content. **Prefer verifying maximum length of 160 characters including this instructions in message content to avoid multiple sending of same sms.**
+          type : string
+          example : send Stop if you want to unsubscribe.
+
+  updateSmsCampaign:
+    type: object
+    properties:
+      name:
+        description: Name of the campaign
+        type: string
+        example: 'Spring Promo Code'
+      sender:
+        description: Name of the sender. **The number of characters is limited to 11 for alphanumeric characters and 15 for numeric characters**
+        type: string
+        maxLength: 15
+        example: 'MyShop'
+      content:
+        description: Content of the message. The maximum characters used per SMS is 160, if used more than that, it will be counted as more than one SMS
+        type: string
+        example: 'Get a discount by visiting our NY store and saying : Happy Spring!'
+      recipients:
+        type: object
+        required:
+          - listIds
+        properties:
+          listIds:
+            description: Lists Ids to send the campaign to. REQUIRED if scheduledAt is not empty
+            type: array
+            items:
+              type: integer
+              format: int64
+              description: List Id to send the campaign to
+              example: 54
+          exclusionListIds:
+            description: List ids which have to be excluded from a campaign
+            type: array
+            items:
+              type: integer
+              format: int64
+              description: List Id to exclude from the campaign
+              example: 15
+      scheduledAt:
+        description: UTC date-time on which the campaign has to run (YYYY-MM-DDTHH:mm:ss.SSSZ). Prefer to pass your timezone in date-time format for accurate result.
+        type: string
+        example: '2017-05-05T12:30:00+02:00'
+      unicodeEnabled:
+          type: boolean
+          description: Format of the message. It indicates whether the content should be treated as unicode or not.
+          example: true
+          default: false
+      organisationPrefix:
+          description : A recognizable prefix will ensure your audience knows who you are. Recommended by U.S. carriers. This will be added as your Brand Name before the message content. **Prefer verifying maximum length of 160 characters including this prefix in message content to avoid multiple sending of same sms.**
+          type: string
+          example: MyCompany
+      unsubscribeInstruction:
+          description : Instructions to unsubscribe from future communications. Recommended by U.S. carriers. Must include **STOP** keyword. This will be added as instructions after the end of message content. **Prefer verifying maximum length of 160 characters including this instructions in message content to avoid multiple sending of same sms.**
+          type : string
+          example : send Stop if you want to unsubscribe.
+
+  sendTransacSms:
+    type: object
+    required:
+      - sender
+      - recipient
+    properties:
+      sender:
+        description: Name of the sender. **The number of characters is limited to 11 for alphanumeric characters and 15 for numeric characters**
+        type: string
+        maxLength: 15
+        example: 'MyShop'
+      recipient:
+        description: Mobile number to send SMS with the country code
+        type: string
+        example: '33689965433'
+      content:
+        description: Content of the message. If more than 160 characters long, will be sent as multiple text messages. **Mandatory if `templateId` is not passed, ignored if `templateId` is passed.**
+        type: string
+        example: 'Enter this code:CCJJG8 to validate your account'
+      templateId:
+        description: Template ID to send SMS with the template. When provided, overrides the `content` parameter. **Mandatory if `content` is not passed.**
+        type: integer
+        example: 123
+      type:
+        description: Type of the SMS. Marketing SMS messages are those sent typically with marketing content. Transactional SMS messages are sent to individuals and are triggered in response to some action, such as a sign-up, purchase, etc.
+        enum:
+          - transactional
+          - marketing
+        default: transactional
+        type: string
+        example: 'marketing'
+      tag:
+          type: object
+          properties:
+            field:
+              oneOf:
+                - type: string
+                - type: array
+                  items:
+                    type: string
+              description: A tag can be a string or an array of strings.
+          description: Tag of the message
+          example: accountValidation | ["tag1", "tag2"]
+      webUrl:
+        description: Webhook to call for each event triggered by the message (delivered etc.)
+        type: string
+        format: url
+        example: 'http://requestb.in/173lyyx1'
+      unicodeEnabled:
+          type: boolean
+          description: Format of the message. It indicates whether the content should be treated as unicode or not.
+          example: true
+          default: false
+      organisationPrefix:
+          type: string
+          description: A recognizable prefix will ensure your audience knows who you are. Recommended by U.S. carriers. This will be added as your Brand Name before the message content. **Prefer verifying maximum length of 160 characters including this prefix in message content to avoid multiple sending of same sms.**
+          example: MyCompany
+      params:
+          type: object
+          additionalProperties: {}
+          description: Pass the set of attributes to customize the template. For example, {"FNAME":"Joe", "LNAME":"Doe"}. These are the placeholder variables in the template that will be replaced with the corresponding values passed in the params object. Applicable only if `templateId` is used.
+          example:
+            FNAME: Joe
+            LNAME: Doe
+
+  sendTestEmail:
+    type: object
+    properties:
+      emailTo:
+        description: List of the email addresses of the recipients whom you wish to send the test mail. If left empty, the test mail will be sent to your entire test list. You can not send more than 50 test emails per day.
+        type: array
+        items:
+          type: string
+          format: email
+          description: Email addres of the recipient
+          example: 'helen.jurger@example.com'
+
+  sendTestSms:
+    type: object
+    properties:
+      phoneNumber:
+        description: Mobile number of the recipient with the country code. This number must belong to one of your contacts in Brevo account and must not be blacklisted
+        type: string
+        example: '33689965433'
+
+  getTransacAggregatedSmsReport:
+    type: object
+    properties:
+      range:
+        type: string
+        description: Time frame of the report
+        example: '2016-09-08|2017-04-06'
+      requests:
+        type: integer
+        format: int64
+        description: Number of requests for the timeframe
+        example: 263
+      delivered:
+        type: integer
+        format: int64
+        description: Number of delivered SMS for the timeframe
+        example: 249
+      hardBounces:
+        type: integer
+        format: int64
+        description: Number of hardbounces for the timeframe
+        example: 1
+      softBounces:
+        type: integer
+        format: int64
+        description: Number of softbounces for the timeframe
+        example: 4
+      blocked:
+        type: integer
+        format: int64
+        description: Number of blocked contact for the timeframe
+        example: 2
+      unsubscribed:
+        type: integer
+        format: int64
+        description: Number of unsubscription for the timeframe
+        example: 6
+      replied:
+        type: integer
+        format: int64
+        description: Number of answered SMS for the timeframe
+        example: 12
+      accepted:
+        type: integer
+        format: int64
+        description: Number of accepted SMS for the timeframe
+        example: 252
+      rejected:
+        type: integer
+        format: int64
+        description: Number of rejected SMS for the timeframe
+        example: 8
+      skipped:
+        type: integer
+        format: int64
+        description: Number of skipped SMS for the timeframe
+        example: 1
+
+  getTransacSmsReport:
+    type: object
+    properties:
+      reports:
+        type: array
+        items:
+          type: object
+          properties:
+            date:
+              type: string
+              format: date
+              description: Date for which statistics are retrieved
+              example: '2017-03-17'
+            requests:
+              type: integer
+              format: int64
+              description: Number of requests for the date
+              example: 87
+            delivered:
+              type: integer
+              format: int64
+              description: Number of delivered SMS for the date
+              example: 85
+            hardBounces:
+              type: integer
+              format: int64
+              description: Number of hardbounces for the date
+              example: 1
+            softBounces:
+              type: integer
+              format: int64
+              description: Number of softbounces for the date
+              example: 1
+            blocked:
+              type: integer
+              format: int64
+              description: Number of blocked contact for the date
+              example: 0
+            unsubscribed:
+              type: integer
+              format: int64
+              description: Number of unsubscription for the date
+              example: 1
+            replied:
+              type: integer
+              format: int64
+              description: Number of answered SMS for the date
+              example: 2
+            accepted:
+              type: integer
+              format: int64
+              description: Number of accepted SMS for the date
+              example: 85
+            rejected:
+              type: integer
+              format: int64
+              description: Number of rejected SMS for the date
+              example: 1
+            skipped:
+              type: integer
+              format: int64
+              description: Number of skipped SMS for the date
+              example: 1
+
+  getIp:
+    type: object
+    required:
+      - id
+      - ip
+      - active
+      - domain
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the dedicated IP
+        example: 3
+      ip:
+        type: string
+        description: Dedicated IP
+        example: '123.65.8.22'
+      active:
+        type: boolean
+        description: Status of the IP (true=active, false=inactive)
+        example: true
+      domain:
+        type: string
+        description: Domain associated to the IP
+        example: 'mailing.myshop.com'
+
+  getIpsFromSender:
+    type: object
+    required:
+      - ips
+    properties:
+      ips:
+        description: Dedicated IP(s) linked to a sender
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/getIpFromSender'
+
+  getIps:
+    type: object
+    required:
+      - ips
+    properties:
+      ips:
+        type: array
+        description: Dedicated IP(s) available on your account
+        items:
+          type: object
+          $ref: '#/definitions/getIp'
+
+  getIpFromSender:
+    type: object
+    required:
+      - id
+      - ip
+      - domain
+      - weight
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the dedicated IP
+        example: 3
+      ip:
+        type: string
+        description: Dedicated IP
+        example: '123.65.8.22'
+      domain:
+        type: string
+        description: Domain associated to the IP
+        example: 'mailing.myshop.dom'
+      weight:
+        type: integer
+        format: int64
+        description: Weight of the IP
+        example: 75
+
+  getTransacEmailContent:
+    type: object
+    required:
+      - email
+      - subject
+      - date
+      - events
+      - body
+      - attachmentCount
+    properties:
+      email:
+        description: Email address to which transactional email has been sent
+        type: string
+        format: email
+        example: "abc@example.com"
+      subject:
+        description: Subject of the sent email
+        type: string
+        example: 'Summer Camp'
+      templateId:
+        description: Id of the template
+        type: integer
+        format: int64
+        example: 2
+      date:
+        description: Date on which transactional email was sent
+        type: string
+        example: "2017-03-12T12:30:00Z"
+      events:
+        description: Series of events which occurred on the transactional email
+        type: array
+        items:
+          type: object
+          required:
+            - name
+            - time
+          properties:
+            name:
+              description: Name of the event that occurred on the sent email
+              type: string
+              example: 'delivered'
+            time:
+              description: Time at which the event occurred
+              type: string
+              example: "2017-03-12T12:30:00Z"
+      body:
+        description: Actual content of the transactional email that has been sent
+        type: string
+        example: "<!DOCTYPE html> <html> <body> <h1>Greetings from the team</h1> <p>This is the actual html content sent</p> </body> </html>"
+      attachmentCount:
+        description: Count of the attachments that were sent in the email
+        type: integer
+        format: int64
+        example: 2
+
+  getTransacEmailsList:
+    type: object
+    properties:
+      count:
+        type: integer
+        description: Total number of transactional emails available on your account according to the passed filter
+        format: int64
+        example: 5
+      transactionalEmails:
+        type: array
+        items:
+          type: object
+          required:
+            - email
+            - subject
+            - messageId
+            - uuid
+            - date
+          properties:
+            email:
+              description: Email address to which transactional email has been sent
+              type: string
+              format: email
+              example: 'john.smith@example.com'
+            subject:
+              description: Subject of the sent email
+              type: string
+              example: 'Summer Camp'
+            templateId:
+              description: Id of the template
+
+              type: integer
+              format: int64
+              example: 2
+            messageId:
+              description: Message Id of the sent email
+              type: string
+              example: '<201798300811.5700093@relay.domain.com>'
+            uuid:
+              description: Unique id of the email sent to a particular contact
+              type: string
+              example: '5a78c-209ok98262910-s99a341'
+            date:
+              description: Date on which transactional email was sent
+              type: string
+              example: '2017-03-12T12:30:00Z'
+            from:
+              description: Email address of the sender from which the email was sent
+              type: string
+              format: email
+              example: 'diana.doe@example.com'
+            tags:
+              description: Tags used for your email
+              type: array
+              items:
+                type: string
+                example: 'tag1'
+
+  abTestVersionStats:
+    description: Percentage of a particular event for both versions
+    type: object
+    required:
+      - Version A
+      - Version B
+    properties:
+      Version A:
+        type: string
+        description : percentage of an event for version A
+        example : '50%'
+      Version B:
+        type: string
+        description : percentage of an event for version B
+        example : '50%'
+
+  abTestVersionClicks:
+    description: Information on clicked links for a particular version
+    type: array
+    items:
+      type: object
+      required:
+        - link
+        - clicksCount
+        - clickRate
+      properties:
+        link:
+          type: string
+          description: URL of the link
+          example: 'https://facbook.com/versionA'
+        clicksCount:
+          type: integer
+          format: int64
+          description: Number of times a link is clicked
+          example: 3
+        clickRate:
+          type: string
+          description: Percentage of clicks of link with respect to total clicks
+          example: 40%
+  blockDomain:
+    type: object
+    required:
+      - domain
+    properties:
+      domain:
+        type: string
+        description: name of the domain to be blocked
+        example: "example.com"
+  getBlockedDomains:
+    description: list of blocked domains
+    type: object
+    required:
+      - domains
+    properties:
+      domains:
+        description: List of all blocked domains
+        type: array
+        items:
+          type: string
+          description: name of blocked domain
+          example: "contact.com"
+
+  getInboundEmailEvents:
+    type: object
+    properties:
+      events:
+        type: array
+        items:
+          type: object
+          required:
+            - uuid
+            - sender
+            - date
+            - recipient
+          properties:
+            uuid:
+              description: 'UUID that can be used to fetch additional data'
+              type: string
+              format: uuid
+            date:
+              description: 'Date when email was received on SMTP relay'
+              type: string
+              format: date-time
+            sender:
+              description: 'Sender’s email address'
+              type: string
+              format: email
+            recipient:
+              description: 'Recipient’s email address'
+              type: string
+              format: email
+  getInboundEmailEventsByUuid:
+    type: object
+    properties:
+      receivedAt:
+        description: 'Date when email was received on SMTP relay'
+        type: string
+        format: date-time
+        example: "2019-05-25T11:53:26Z"
+      deliveredAt:
+        description: 'Date when email was delivered successfully to client’s webhook'
+        type: string
+        format: date-time
+      recipient:
+        description: 'Recipient’s email address'
+        type: string
+        format: email
+      sender:
+        description: 'Sender’s email address'
+        type: string
+        format: email
+      messageId:
+        description: 'Value of the Message-ID header. This will be present only after the processing is done.'
+        type: string
+      subject:
+        description: 'Value of the Subject header. This will be present only after the processing is done. '
+        type: string
+      attachments:
+        description: 'List of attachments of the email. This will be present only after the processing is done.'
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              description: 'filename specified in the Content-Disposition header of the attachment'
+              type: string
+            contentType:
+              description: 'value of the Content-Type header of the attachment'
+              type: string
+            contentId:
+              description: 'value of the Content-ID header of the attachment.'
+              type: string
+            contentLength:
+              description: 'size of the attachment in bytes'
+              type: integer
+      logs:
+        description: 'List of events/logs that describe the lifecycle of the email on SIB platform'
+        type: array
+        items:
+          type: object
+          properties:
+            date:
+              description: 'Date of the event'
+              type: string
+              format: date-time
+            type:
+              description: 'Type of the event'
+              type: string
+              enum:
+                - received
+                - processed
+                - webhookFailed
+                - webhookDelivered
+  getScheduledEmailByBatchId:
+    type: object
+    properties:
+      count:
+        type: integer
+        description: 'Total number of batches'
+      batches:
+        type: array
+        items:
+          type: object
+          required:
+            - scheduledAt
+            - createdAt
+            - status
+          properties:
+            scheduledAt:
+              description: 'Datetime for which the batch was scheduled'
+              type: string
+              format: date-time
+            createdAt:
+              description: 'Datetime on which the batch was scheduled'
+              type: string
+              format: date-time
+            status:
+              description: 'Current status of the scheduled batch'
+              type: string
+              enum:
+              - inProgress
+              - queued
+              - processed
+              - error
+  getScheduledEmailByMessageId:
+    type: object
+    required:
+      - scheduledAt
+      - createdAt
+      - status
+    properties:
+      scheduledAt:
+        description: 'Datetime for which the email was scheduled'
+        type: string
+        format: date-time
+      createdAt:
+        description: 'Datetime on which the email was scheduled'
+        type: string
+        format: date-time
+      status:
+        description: 'Current status of the scheduled email'
+        type: string
+        enum:
+        - inProgress
+        - queued
+        - processed
+        - error
+  subAccountsResponse:
+    type: object
+    properties:
+      count:
+        type: integer
+        description: 'Total number of subaccounts'
+      subAccounts:
+        type: array
+        items:
+          type: object
+          required:
+            - id
+            - companyName
+            - active
+            - createdAt
+            - groups
+          properties:
+            id:
+              description: 'id of the sub-account'
+              type: integer
+              format: int64
+            companyName:
+              description: 'Name of the sub-account company'
+              type: string
+            active:
+              description: 'Whether the sub-account is active or not'
+              type: boolean
+            createdAt:
+              description: 'Timestamp when the sub-account was created'
+              type: integer
+              format: int64
+            groups:
+                description: Group details
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: Group identifier
+                    name:
+                      type: string
+                      description: Name of the group
+  createSubAccount:
+    type: object
+    required:
+      - companyName
+      - email
+    properties:
+      companyName:
+        description: 'Set the name of the sub-account company'
+        type: string
+      email:
+        description: 'Email address for the organization'
+        type: string
+      language:
+        description: 'Set the language of the sub-account'
+        type: string
+        enum:
+          - en
+          - fr
+          - it
+          - es
+          - pt
+          - de
+      timezone:
+        description: 'Set the timezone of the sub-account'
+        type: string
+      groupIds:
+        description: 'Set the group(s) for the sub-account'
+        type: array
+        items:
+          type: string
+    example:
+      companyName: 'Test Sub-account'
+      email: test-sub@example.com
+      timezone: Europe/Paris
+      language: fr
+      groupIds: ["5f8f8c3b5f56a02d4433b3a7", "5f8f8c3b5f56a02d4433b3a8"]
+
+
+  createSubAccountResponse:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: integer
+        format: int64
+        description: ID of the sub-account created
+        example: 122
+  corporateGroupDetailsResponse:
+      type: object
+      properties:
+        group:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Group id
+            groupName:
+              type: string
+              description: Name of the group
+            createdAt:
+              type: string
+              description: Group creation date
+        sub-accounts:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: integer
+                format: int64
+                description: Id of the sub-account organzation
+              companyName:
+                type: string
+                description: Name of the sub-account organzation
+              createdAt:
+                type: string
+                description: Creation date of the sub-account organzation
+        users:
+          type: array
+          items:
+            type: object
+            properties:
+              email:
+                type: string
+                description: Email address of the user
+              lastName:
+                type: string
+                description: Last name of the user
+              firstName:
+                type: string
+                description: First name of the user
+  masterDetailsResponse:
+      type: object
+      properties:
+        email:
+          type: string
+          description: Email id of master account
+        companyName:
+          type: string
+          description: Company name of master account organization
+        id:
+          type: integer
+          format: int64
+          description: Unique identifier of the master account organization
+        currencyCode:
+          type: string
+          description: Currency code of the master account organization
+        timezone:
+          type: string
+          description: Timezone of the master account organization
+        billingInfo:
+          type: object
+          description: Billing details of the master account organization
+          properties:
+            email:
+              type: string
+              description: Billing email id of master account
+            companyName:
+              type: string
+              description: Company name of master account
+            name:
+              type: object
+              description: Billing name of master account holder
+              properties:
+                givenName:
+                  type: string
+                  description: First name for billing
+                familyName:
+                  type: string
+                  description: Last name for billing
+            address:
+              type: object
+              description: Billing address of master account
+              properties:
+                streetAddress:
+                  type: string
+                  description: Street address
+                locality:
+                  type: string
+                  description: Locality
+                postalCode:
+                  type: string
+                  description: Postal code
+                stateCode:
+                  type: string
+                  description:  State code
+                countryCode:
+                  type: string
+                  description: Country code
+        planInfo:
+          type: object
+          description: Plan details
+          properties:
+            currencyCode:
+              type: string
+              description: Plan currency
+            nextBillingAt:
+              type: integer
+              format: int64
+              description: Timestamp of next billing date
+            price:
+              type: number
+              description: Plan amount
+            planPeriod:
+              type: string
+              description: Plan period type
+              enum:
+                - month
+                - year
+            subAccounts:
+              type: integer
+              description: Number of sub-accounts
+            features:
+              type: array
+              description: List of provided features in the plan
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Name of the feature
+                  unitValue:
+                    type: string
+                    description: Unit value of the feature
+                  quantity:
+                    type: integer
+                    format: int64
+                    description: Quantity provided in the plan
+                  quantityWithOverages:
+                    type: integer
+                    format: int64
+                    description: Quantity with overages provided in the plan (only applicable on ENTv2)
+                  used:
+                    type: integer
+                    format: int64
+                    description: Quantity consumed by master
+                  usedOverages:
+                    type: integer
+                    format: int64
+                    description: Quantity consumed by sub-organizations over the admin plan limit (only applicable on ENTv2)
+                  remaining:
+                    type: integer
+                    format: int64
+                    description: Quantity remaining in the plan
+  createApiKeyResponse:
+    type: object
+    properties:
+      status:
+        type: string
+        description: Status of the API operation.
+      key:
+        type: string
+        description: API Key
+
+  subAccountDetailsResponse:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Name of the sub-account user
+      email:
+        type: string
+        description: Email id of the sub-account organization
+      companyName:
+        type: string
+        description: Sub-account company name
+      groups:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: string
+              description: Group id
+            name:
+              type: string
+              description: Name of the group
+        description: List of group(s) associated with the sub-account
+      planInfo:
+        type: object
+        description: Sub-account plan details
+        properties:
+          credits:
+            type: object
+            description: Credits quota and remaining credits on the sub-account
+            properties:
+              emails:
+                type: object
+                description: Email credits remaining on the sub-account
+                properties:
+                  quantity:
+                    type: integer
+                    format: int64
+                    description: Quantity of email messaging limits provided
+                  remaining:
+                    type: integer
+                    format: int64
+                    description: Available email messaging limits for use
+              sms:
+                  type: object
+                  description: SMS credits remaining on the sub-account
+                  properties:
+                    quantity:
+                      type: integer
+                      format: int64
+                      description: Quantity of SMS messaging limits provided
+                    remaining:
+                      type: integer
+                      format: int64
+                      description: Available SMS messaging limits for use
+              wpSubscribers:
+                  type: object
+                  description: Push credits remaining on the sub-account
+                  properties:
+                    quantity:
+                      type: integer
+                      format: int64
+                      description: Quantity of Push sending limits provided
+                    remaining:
+                      type: integer
+                      format: int64
+                      description: Available Push sending limits for use
+              whatsapp:
+                  type: object
+                  description: Whatsapp credits remaining on the sub-account
+                  properties:
+                    quantity:
+                      type: integer
+                      format: int64
+                      description: Quantity of whatsapp messaging limits provided
+                    remaining:
+                      type: integer
+                      format: int64
+                      description: Available whatsapp messaging limits for use
+              externalFeeds:
+                  type: object
+                  description: externalFeeds credits remaining on the sub-account
+                  properties:
+                    quantity:
+                      type: integer
+                      format: int64
+                      description: Quantity of externalFeeds messaging limits provided
+                    remaining:
+                      type: integer
+                      format: int64
+                      description: Available externalFeeds messaging limits for use
+          features:
+            type: object
+            description: Features available on the sub-account
+            properties:
+              inbox:
+                type: object
+                description: Inbox details / Not available on ENTv2
+                properties:
+                  quantity:
+                    type: integer
+                    format: int64
+                    description: Quantity of inbox provided
+                  remaining:
+                    type: integer
+                    format: int64
+                    description: Available inboxes for use
+              landingPage:
+                type: object
+                description: Landing page details / Not available on ENTv2
+                properties:
+                  quantity:
+                    type: integer
+                    format: int64
+                    description: Quantity of landing pages provided
+                  remaining:
+                    type: integer
+                    format: int64
+                    description: Available landing pages for use
+              users:
+                type: object
+                description: Marketing users to manage the marketing channels
+                properties:
+                  quantity:
+                    type: integer
+                    format: int64
+                    description: Quantity of marketing users provided
+                  remaining:
+                    type: integer
+                    format: int64
+                    description: Available marketing users for use
+              salesUsers:
+                type: object
+                description: Sales and service users to use phone, sales and conversations
+                properties:
+                  quantity:
+                    type: integer
+                    format: int64
+                    description: Quantity of sales users provided
+                  remaining:
+                    type: integer
+                    format: int64
+                    description: Available sales users for use
+          planType:
+            type: string
+            description: type of the plan
+  subAccountUpdatePlanRequest:
+    type: object
+    description: Details of the plan to be changed
+    properties:
+      credits:
+        type: object
+        description: Credit details to update
+        properties:
+          email:
+            type: integer
+            format: int64
+            description: Number of email credits | Pass the value -1 for unlimited emails in ENTv2 only
+          sms:
+            type: number
+            format: float
+            description: Number of SMS credits | Pass the value -1 for unlimited SMS in ENTv2 only
+          wpSubscribers:
+            type: integer
+            format: int64
+            description: Number of Push credits, possible value is 0 and -1 | available in ENT-v2 only
+          externalFeeds:
+            type: number
+            format: int64
+            description: Number of externalFeeds credits, possible values are 0 or 1 |available in ENTv2 only
+          whatsapp:
+            type: number
+            format: float
+            description: Number of whatsapp credits | Pass the value -1 for unlimited whatsapp in ENTv2 only
+      features:
+        type: object
+        description: Features details to update
+        properties:
+          users:
+            type: integer
+            format: int64
+            description: Number of multi-users
+          landingPage:
+            type: integer
+            format: int64
+            description: Number of landing pages
+          inbox:
+            type: integer
+            format: int64
+            description: Number of inboxes / Not required on ENTv2
+          salesUsers:
+              type: integer
+              format: int64
+              description: Number of sales users
+    example:
+      credits:
+        email: 5000
+        sms: 2000
+        wpSubscribers: -1
+        externalFeeds: 1
+        whatsapp: 100
+      features:
+        users: 15
+        landingPage: 20
+        inbox: 10
+        salesUsers: 6
+  subAccountsUpdatePlanRequest:
+      type: object
+      description: Details of the plan to be changed
+      properties:
+        subAccountIds:
+          type: array
+          description: List of sub-account ids
+          items:
+            type: integer
+            format: int64
+        credits:
+          type: object
+          description: Credit details to update
+          properties:
+            email:
+              type: integer
+              format: int64
+              description: Number of email credits | Pass the value -1 for unlimited emails in ENTv2 only
+            sms:
+              type: number
+              format: float
+              description: Number of SMS credits | Pass the value -1 for unlimited SMS in ENTv2 only
+            wpSubscribers:
+              type: integer
+              format: int64
+              description: Number of Push credits, possible value is 0 and -1 | available in ENTv2 only
+            externalFeeds:
+              type: number
+              format: int64
+              description: Number of externalFeeds credits, possible values are 0 or 1 |available in ENTv2 only
+            whatsapp:
+              type: number
+              format: float
+              description: Number of whatsapp credits | Pass the value -1 for unlimited whatsapp in ENTv2 only
+        features:
+          type: object
+          description: Features details to update
+          properties:
+            users:
+              type: integer
+              format: int64
+              description: Number of multi-users
+            landingPage:
+              type: integer
+              format: int64
+              description: Number of landing pages
+            salesUsers:
+              type: integer
+              format: int64
+              description: Number of sales users
+      example:
+        subAccountIds: [4534345, 987893, 876785]
+        credits:
+          email: 5000
+          sms: 2000
+          wpSubscribers: -1
+          externalFeeds: 1
+          whatsapp: 100
+        features:
+          users: 15
+          landingPage: 20
+          salesUsers: 6
+  subAccountAppsToggleRequest:
+      type: object
+      description: List of enable/disable applications on the sub-account
+      properties:
+        inbox:
+          type: boolean
+          description: Set this field to enable or disable Inbox on the sub-account / Not applicable on ENTv2
+        whatsapp:
+          type: boolean
+          description: Set this field to enable or disable Whatsapp campaigns on the sub-account
+        automation:
+          type: boolean
+          description: Set this field to enable or disable Automation on the sub-account
+        email-campaigns:
+          type: boolean
+          description: Set this field to enable or disable Email Campaigns on the sub-account
+        sms-campaigns:
+          type: boolean
+          description: Set this field to enable or disable SMS Marketing on the sub-account
+        landing-pages:
+          type: boolean
+          description: Set this field to enable or disable Landing pages on the sub-account
+        transactional-emails:
+          type: boolean
+          description: Set this field to enable or disable Transactional Email on the sub-account
+        transactional-sms:
+          type: boolean
+          description: Set this field to enable or disable Transactional SMS on the sub-account
+        facebook-ads:
+          type: boolean
+          description: Set this field to enable or disable Facebook ads on the sub-account
+        web-push:
+          type: boolean
+          description: Set this field to enable or disable Web Push on the sub-account
+        meetings:
+          type: boolean
+          description: Set this field to enable or disable Meetings on the sub-account
+        conversations:
+          type: boolean
+          description: Set this field to enable or disable Conversations on the sub-account
+        crm:
+          type: boolean
+          description: Set this field to enable or disable Sales CRM on the sub-account
+      example:
+          landing-pages: true
+          sms-campaigns: false
+          whatsapp: true
+          meetings: true
+          web-push: false
+  TaskTypes:
+    type: object
+    description: Task types details
+    properties:
+      id:
+        type: string
+        description: Id of task type
+        example: "61a88a2eb7a574180261234"
+      title:
+        type: string
+        description: Title of task type
+        example: "Email"
+  Task:
+    required:
+    - taskTypeId
+    - name
+    - date
+    type: object
+    description: Task Details
+    properties:
+      id:
+        type: string
+        description: Unique task id
+        example: "61a5cd07ca1347c82306ad06"
+      taskTypeId:
+        type: string
+        description: Id for type of task e.g Call / Email / Meeting etc.
+        example: "61a5cd07ca1347c82306ad09"
+      name:
+        type: string
+        description: Name of task
+        example: "Task: Connect with client"
+      contactsIds:
+        items:
+          type: integer
+        type: array
+        description: Contact ids for contacts linked to this task
+        example: [ 1, 2, 3]
+      dealsIds:
+        items:
+          type: string
+        type: array
+        description: Deal ids for deals a task is linked to
+        example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+      companiesIds:
+        items:
+          type: string
+        type: array
+        description: Companies ids for companies a task is linked to
+        example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+  TaskReminder:
+    required:
+    - value
+    - unit
+    - types
+    type: object
+    description: Task reminder date/time for a task
+    properties:
+      value:
+        type: integer
+        example: 10
+        description: Value of time unit before reminder is to be sent
+      unit:
+        type: string
+        enum:
+          - minutes
+          - hours
+          - weeks
+          - days
+        description: Unit of time before reminder is to be sent
+      types:
+        items:
+          type: string
+        enum:
+          - email
+          - push
+        description: Type of task reminder e.g email, push
+        type: array
+        example: [
+          "email"
+          ]
+  FileList:
+      type: array
+      description: List of files
+      items:
+        $ref: '#/definitions/FileData'
+  FileDownloadableLink:
+    type: object
+    required:
+     - fileUrl
+    properties:
+      fileUrl:
+        type: string
+        format: url
+        description: A unique link to download the requested file.
+        example: 'https://storage.googleapis.com/brevo-app-crm.......-sample.pdf'
+  FileData:
+    type: object
+    description: File data that is uploaded
+    properties:
+      name:
+        type: string
+        description: Name of uploaded file
+        example: "example.png"
+      authorId:
+        type: string
+        description: Account id of user which created the file
+        example: "61a5ce58y5d4795761045991"
+      contactId:
+        type: integer
+        format: int64
+        description: Contact id of contact on which file is uploaded
+        example: 1
+      dealId:
+        type: string
+        description: Deal id linked to a file
+        example: "61a5ce58c5d4795761045991"
+      companyId:
+        type: string
+        description: Company id linked to a file
+        example: "61a5ce58c5d4795761045991"
+      size:
+        type: integer
+        format: int64
+        description: Size of file in bytes
+        example: 10
+      createdAt:
+        type: string
+        format: date-time
+        example: "2017-05-01T17:05:03.000Z"
+        description: File created date/time
+  NoteData:
+    required:
+    - text
+    type: object
+    description: Note data to be saved
+    properties:
+      text:
+        type: string
+        maxLength: 3000
+        minLength: 1
+        example: "In communication with client for resolution of queries."
+        description: Text content of a note
+      contactIds:
+        items:
+          type: integer
+        description: Contact Ids linked to a note
+        type: array
+        example: [
+          247, 1, 2
+          ]
+      dealIds:
+        items:
+          type: string
+        description: Deal Ids linked to a note
+        type: array
+        example: [
+          "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991"
+          ]
+      companyIds:
+        items:
+          type: string
+        description: Company Ids linked to a note
+        type: array
+        example: [
+          "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991"
+          ]
+      isPinned:
+          type: boolean
+          example: true
+          description: When creating a note, set it to "true" to pin it. Otherwise, the default value of "false" will be applied.
+
+  Note:
+    required:
+    - text
+    type: object
+    description: Note Details
+    properties:
+      id:
+        type: string
+        description: Unique note Id
+        example: "61a5cd07ca1347c82306ad09"
+      text:
+        type: string
+        maxLength: 3000
+        minLength: 1
+        example: "In communication with client for resolution of queries."
+        description: Text content of a note
+      contactIds:
+        items:
+          type: integer
+        description: Contact ids linked to a note
+        type: array
+        example: [
+          247, 1, 2
+          ]
+      dealIds:
+        items:
+          type: string
+        description: Deal ids linked to a note
+        type: array
+        example: [
+          "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991"
+          ]
+      authorId:
+        type: object
+        description: Account details of user which created the note
+        example: {
+          id: "61a5ce58y5d4795761045991",
+          email: "johndoe@example.com",
+          locale: "en_GB",
+          timezone: "Asia/Kolkata",
+          name: {
+              fullName: "John Doe"
+            }
+          }
+      createdAt:
+        type: string
+        format: date-time
+        example: "2017-05-01T17:05:03.000Z"
+        description: Note created date/time
+      updatedAt:
+        type: string
+        format: date-time
+        example: "2017-05-01T17:05:03.000Z"
+        description: Note updated date/time
+      pinnedAt:
+        type: string
+        format: date-time
+        example: "2017-05-01T17:05:03.000Z"
+        description: Note pinned date/time
+  NoteId:
+    type: object
+    description: Updated Note ID
+    properties:
+      id:
+        type: string
+        description: Unique note Id
+        example: "61a5cd07ca1347c82306ad09"
+  NoteList:
+      type: array
+      description: List of notes
+      items:
+        $ref: '#/definitions/Note'
+  TaskList:
+    type: object
+    description: List of tasks
+    properties:
+      items:
+        type: array
+        description: List of tasks
+        items:
+          $ref: '#/definitions/Task'
+  PipelineStage:
+      type: object
+      description: List of stages
+      properties:
+        id:
+          type: string
+          description: Stage id
+          example: "9e577ff7-8e42-4ab3-be26-2b5e01b42518"
+        name:
+          type: string
+          description: Stage name
+          example: "New"
+  Pipeline:
+      type: object
+      description: List of stages
+      properties:
+        pipeline:
+            type: string
+            description: Pipeline id
+            example: "5ea675e3da0dd085acaea610"
+        pipeline_name:
+            type: string
+            description: Pipeline Name
+            example: Sales Pipeline
+        stages:
+          type: array
+          description: List of stages
+          items:
+            $ref: '#/definitions/PipelineStage'
+  Pipelines:
+      type: array
+      description: List of pipeline
+      items:
+        $ref: '#/definitions/Pipeline'
+  DealAttributes:
+      type: array
+      description: List of deal attributes
+      items:
+        type: object
+        description: List of attributes
+        properties:
+          internalName:
+            type: string
+            example : "deal_name"
+          label:
+            type: string
+            example : "Deal Name"
+          attributeTypeName:
+            type: string
+            example : "text"
+          attributeOptions:
+            type: array
+            items:
+              type: object
+              example : {
+                key: "custom key",
+                value: "custom label"
+              }
+          isRequired:
+            type: boolean
+            example : true
+  DealsList:
+    type: object
+    description: List of Deals
+    properties:
+      items:
+        type: array
+        description: List of deals
+        items:
+          $ref: '#/definitions/Deal'
+  Deal:
+    type: object
+    description: Deal Details
+    properties:
+      id:
+        type: string
+        description: Unique deal id
+        example: "629475917295261d9b1f4403"
+      attributes:
+        type: object
+        description: Deal attributes with values
+        example :  {
+          deal_name: "testname",
+          deal_owner: "6093d2425a9b436e9519d034",
+          amount: 12,
+          pipeline: "6093d296ad1e9c5cf2140a58",
+          deal_stage: "9e577ff7-8e42-4ab3-be26-2b5e01b42518",
+          stage_updated_at: "2022-05-30T07:42:05.671Z",
+          created_at: "2022-05-30T07:42:05.671Z",
+          number_of_contacts: 1,
+          last_updated_date: "2022-06-06T08:38:36.761Z",
+          last_activity_date: "2022-06-06T08:38:36.000Z",
+          next_activity_date: null,
+          number_of_activities: 0
+        }
+      linkedContactsIds:
+        items:
+          type: integer
+        type: array
+        description: Contact ids for contacts linked to this deal
+        example: [ 1, 2, 3]
+      linkedCompaniesIds:
+        items:
+          type: string
+        type: array
+        description: Companies ids for companies linked to this deal
+        example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+  CompaniesList:
+      type: object
+      description: List of companies
+      properties:
+        items:
+          type: array
+          description: List of compaies
+          items:
+            $ref: '#/definitions/Company'
+  Company:
+      type: object
+      description: Company Details
+      properties:
+        id:
+          type: string
+          description: Unique company id
+          example: "629475917295261d9b1f4403"
+        attributes:
+          type: object
+          description: Company attributes with values
+          example :  {
+              "created_at": "2022-01-13T19:04:24.376+05:30",
+              "domain": "xyz",
+              "last_updated_at": "2022-04-01T18:47:48.283+05:30",
+              "name": "text",
+              "number_of_contacts": 0,
+              "owner": "62260474111b1101704a9d85",
+              "owner_assign_date": "2022-04-01T18:21:13.379+05:30",
+              "phone_number": 8171844192,
+              "revenue": 10
+          }
+        linkedContactsIds:
+          items:
+            type: integer
+          type: array
+          format: int64
+          description: Contact ids for contacts linked to this company
+          example: [ 1, 2, 3]
+        linkedDealsIds:
+          items:
+            type: string
+          type: array
+          format: objectID
+          description: Deals ids for companies linked to this company
+          example: [ "61a5ce58c5d4795761045990", "61a5ce58c5d4795761045991" , "61a5ce58c5d4795761045992"]
+  CompanyAttributes:
+        type: array
+        description: List of company attributes
+        items:
+          type: object
+          description: List of attributes
+          properties:
+            internalName:
+              type: string
+              example : "name"
+            label:
+              type: string
+              example : "Company Name"
+            attributeTypeName:
+              type: string
+              example : "text"
+            attributeOptions:
+              type: array
+              items:
+                type: object
+                example : {
+                  key: "custom key",
+                  value: "custom label"
+                }
+            isRequired:
+              type: boolean
+              example : true
+  ConversationsMessage:
+    type: object
+    description: a Conversations message
+    properties:
+      id:
+        type: string
+        description: Message ID. It can be used for further manipulations with the message.
+        example: eYBEm3gq3zc5ayE2g
+      type:
+        type: string
+        enum: ["agent", "visitor"]
+        description: '`"agent"` for agents’ messages, `"visitor"` for visitors’ messages.'
+        example: agent
+      text:
+        type: string
+        description: Message text or name of the attached file
+        example: Good morning! How can I help you?
+      subject:
+        type: string
+        description: The subject line of the email message (only for messages sent to email threads).
+        example: Invitation to a meeting
+        html:
+          type: string
+          description: The HTML content of the message.
+          example: Good morning!<br>How can I help you?
+        rawUnsafeHtml:
+          type: string
+          description: Unescaped HTML content of the message (may include unsafe HTML).
+          example: Good morning!<br>How can I help you?
+      visitorId:
+        type: string
+        description: visitor’s ID
+        example: kZMvWhf8npAu3H6qd57w2Hv6nh6rnxvg
+      agentId:
+        type: string
+        description: ID of the agent on whose behalf the message was sent (only in messages sent by an agent).
+        example: d9nKoegKSjmCtyK78
+      agentName:
+        type: string
+        description: Agent’s name as displayed to the visitor. Only in the messages sent by an agent.
+        example: Liz
+      createdAt:
+        type: integer
+        format: int64
+        minimum: 0
+        description: Timestamp in milliseconds.
+        example: 1470222622433
+      isPushed:
+        type: boolean
+        description: '`true` for pushed messages'
+        example: true
+      isTrigger:
+        type: boolean
+        description: '`true` for automatic messages from “Targeted chats & triggers” and API (https://developers.brevo.com/docs/javascript-api-reference#sendautomessage)'
+        example: false
+      isMissed:
+        type: boolean
+        description: '`true` for missed and offline messages.'
+        example: false
+      isMissedByVisitor:
+        type: boolean
+        description: "`true` for unread agent’s messages in finished chats."
+        example: false
+      agentUserpic:
+        type: string
+        description: Only set if the agent has uploaded a profile picture.
+        example: 'https://www.brevo.com/'
+      receivedFrom:
+        type: string
+        description: In two-way integrations, messages sent via REST API can be marked with receivedFrom property and then filtered out when received in a webhook to avoid infinite loop.
+        example: SuperAwesomeHelpdesk
+      file:
+        type: object
+        properties:
+          filename:
+            type: string
+            description: Name of the file
+            example: conversations.png
+          size:
+            type: integer
+            format: int64
+            minimum: 0
+            description: Size in bytes
+            example: 15538
+          isImage:
+            type: boolean
+            description: Whether the file is an image
+            example: true
+          url:
+            type: string
+            format: url
+            description: URL of the file
+            example: https://ucarecdn.com/cee5c10c-8302-45c1-b1fb-43860ca941a9/
+          imageInfo:
+            type: object
+            description: image info is passed in case the file is an image
+            properties:
+              width:
+                type: integer
+                format: int64
+                minimum: 0
+                description: Width of the image
+                example: 1129
+              height:
+                type: integer
+                format: int64
+                minimum: 0
+                description: height of the image
+                example: 525
+              previewUrl:
+                type: string
+                format: url
+                description: URL of the preview
+                example: https://ucarecdn.com/03cd56cd-1de9-4f65-996d-08afdf27fa1b/-/preview/800x800/-/quality/lighter/
+
+      from:
+        type: object
+        description: An object containing details about the email sender (applicable only to messages in email threads).
+        properties:
+          email:
+            type: string
+          name:
+            type: string
+      to:
+        type: array
+        description: An array containing details of the recipients (applicable only to messages in email threads).
+        items:
+          type: object
+          properties:
+            email:
+              type: string
+            name:
+              type: string
+      replyTo:
+        type: object
+        description: An object containing details of the reply-to email address (applicable only to messages in email threads).
+        properties:
+          email:
+            type: string
+          name:
+            type: string
+      cc:
+        type: array
+        description: An array containing details of the carbon copy (CC) recipients (applicable only to messages in email threads).
+        items:
+          type: object
+          properties:
+            email:
+              type: string
+            name:
+              type: string
+      bcc:
+        type: array
+        description: An array containing details of the blind carbon copy (BCC) recipients (applicable only to messages in email threads).
+        items:
+          type: object
+          properties:
+            email:
+              type: string
+            name:
+              type: string
+      sourceMessageId:
+        type: string
+        description: The ID of the message assigned by the integration source.
+      forwardedToSourceStatus:
+        type: object
+        description: Status of the message forwarding to the source.
+        properties:
+          isSuccess:
+            type: boolean
+          error:
+            type: string
+      integrations:
+        type: object
+        description: Integration details.
+      isBot:
+        type: boolean
+        description: '`true` for automated messages generated by an AI bot.'
+      attachments:
+        type: array
+        description: An array of file attachments.
+        items:
+          type: object
+          properties:
+            fileName:
+              type: string
+              description: The name of the file.
+            isInline:
+              type: string
+              description: '`true` for inline files.'
+            inlineId:
+              type: string
+              description: The ID of the inline file.
+            url:
+              type: string
+              description: The URL of the file.
+            isImage:
+              type: boolean
+              description: '`true` for images.'
+            size:
+              type: integer
+              format: int64
+              description: The size of the file in bytes.
+  ConversionSourceMetrics:
+    type: object
+    required:
+      - id
+      - conversionSource
+      - ordersCount
+      - revenue
+      - averageBasket
+    properties:
+      id:
+        type: string
+      conversionSource:
+        type: string
+        enum:
+        - email_campaign
+        - sms_campaign
+        - automation_workflow_email
+        - automation_workflow_sms
+      ordersCount:
+        type: number
+        format: integer
+      revenue:
+        type: number
+        format: float
+      averageBasket:
+        type: number
+        format: float
+  ConversionSourceProduct:
+    type: object
+    required:
+      - id
+    properties:
+      id:
+        type: string
+        example: "1"
+      name:
+        type: string
+        example: "Milky Way Galaxy"
+      sku:
+        type: string
+        example: "sku-1"
+      price:
+        type: number
+        format: float
+        example: 1000.0
+      url:
+        type: string
+        example: "https://mydomain.com/products/alpina-panoma-classic"
+      imageUrl:
+        type: string
+        example: "http://mydomain.com/product-absoulte-url/img.jpeg"
+      ordersCount:
+        type: integer
+        example: 200
+      revenue:
+        type: number
+        format: float
+        example: 999.99
+  order:
+      type: object
+      required:
+      - id
+      - createdAt
+      - updatedAt
+      - status
+      - amount
+      - products
+      properties:
+        id:
+          description: 'Unique ID of the order.'
+          type: string
+          example: "14"
+        createdAt:
+          description: 'Event occurrence UTC date-time (YYYY-MM-DDTHH:mm:ssZ), when order is actually created.'
+          type: string
+          example: "2021-07-29T20:59:23.383Z"
+        updatedAt:
+          description: 'Event updated UTC date-time (YYYY-MM-DDTHH:mm:ssZ), when the status of the order is actually changed/updated.'
+          type: string
+          example: "2021-07-30T10:59:23.383Z"
+        status:
+          description: 'State of the order.'
+          type: string
+          example: "completed"
+        amount:
+          description: 'Total amount of the order, including all shipping expenses, tax and the price of items.'
+          type: number
+          example: 308.42
+        storeId:
+          description: 'ID of store where the order is placed'
+          type: string
+          example: "ST-21"
+        identifiers:
+          description: 'Identifies the contact associated with the order.'
+          type: object
+          properties:
+            ext_id:
+              type: string
+              description: 'ext_id associated with the order'
+              example: "ext_id_1"
+            loyalty_subscription_id:
+              type: string
+              description: 'loyalty_subscription_id associated with the order'
+              example: "loyalty_id_1"
+            phone_id:
+              type: string
+              description: 'Phone number of the contact associated with the order'
+              example: "01559 032133"
+            email_id:
+              type: string
+              description: 'Email of the contact associated with the order'
+              example: "example@brevo.com"
+        products:
+          type: array
+          items:
+            type: object
+            required:
+            - productId
+            - quantity
+            - price
+            description: 'Details for the Products in an order.'
+            properties:
+              productId:
+                type: string
+                description: 'ID of the product.'
+                example: "P1"
+              quantity:
+                type: number
+                description: 'How many pieces of the product the visitor has added to the cart.'
+                example: 10
+              variantId:
+                type: string
+                description: 'Product ID of the red color shirts.'
+                example: "P100"
+              price:
+                type: number
+                description: 'The price of a unit of product'
+                example: 99.99
+        billing:
+          description: 'Billing details of an order.'
+          type: object
+          properties:
+            address:
+              type: string
+              description: 'Full billing address.'
+              example: "15 Somewhere Road, Brynmenyn"
+            city:
+              type: string
+              description: 'Exact city of the address.'
+              example: "Basel"
+            countryCode:
+              type: string
+              description: 'Billing country 2-letter ISO code.'
+              example: "CA"
+            country:
+              type: string
+              description: 'Billing country name.'
+              example: "Canada"
+            phone:
+              type: string
+              description: 'Billing phone number.'
+              example: "01559 032133"
+            postCode:
+              type: string
+              description: 'Postcode for delivery and billing.'
+              example: "4052"
+            paymentMethod:
+              type: string
+              description: 'How the visitor will pay for the item(s), e.g. paypal, check, etc.'
+              example: "PayPal"
+            region:
+              type: string
+              description: 'Exact region (state/province) for delivery and billing.'
+              example: "Northwestern Switzerland"
+        coupons:
+          description: 'Coupons applied to the order. Stored case insensitive.'
+          type: array
+          example:
+            - "EASTER15OFF"
+          items:
+           type: string
+        metaInfo:
+          type: object
+          additionalProperties:
+           oneOf:
+             - type: string
+             - type: integer
+             - type: boolean
+          description: Meta data of order to store additional detal such as custom message, customer type, source.
+          example: {
+            "order_source": "Website",
+            "gift_message": "Happy Birthday!",
+            "customer_loyalty_tier": "Gold"
+          }
+
+  orderBatch:
+      type: object
+      required:
+      - orders
+      properties:
+        orders:
+          description: "array of order objects"
+          type: array
+          items:
+            $ref: '#/definitions/order'
+        notifyUrl:
+          description: 'Notify Url provided by client to get the status of batch request'
+          type: string
+          example: "https://en.wikipedia.org/wiki/Webhook"
+        historical:
+          description: 'Defines wether you want your orders to be considered as live data or as historical data (import of past data, synchronising data). True: orders will not trigger any automation workflows. False: orders will trigger workflows as usual.'
+          type: boolean
+          default: true
+          example: true
+
+  createdBatchId:
+      type: object
+      required:
+        - batchId
+      properties:
+        batchId:
+          type: number
+          description: 'Batch ID of the request'
+          example: '1'
+  getOrders:
+      type: object
+      properties:
+        orders:
+          type: array
+          items:
+            type: object
+            allOf:
+            - type: object
+              properties:
+                contact_id:
+                  type: integer
+                  description: Contact ID for the order
+                  format: int64
+                  example: 187588
+            - $ref: '#/definitions/order'
+        count:
+          type: integer
+          description: Number of orders
+          format: int64
+          example: 17655
+  getCategories:
+      required:
+      - categories
+      - count
+      type: object
+      properties:
+        categories:
+          type: array
+          items:
+            type: object
+            allOf:
+            - $ref: '#/definitions/getCategoryDetails'
+        count:
+          type: integer
+          description: Number of categories
+          format: int64
+          example: 17655
+
+  getCategoryDetails:
+      required:
+      - id
+      - name
+      - createdAt
+      - modifiedAt
+      type: object
+      properties:
+        id:
+          type: string
+          description: Category ID for which you requested the details
+          format: string
+          example: C11
+        name:
+          type: string
+          description: Name of the category for which you requested the details
+          format: string
+          example: Electronics
+        createdAt:
+          type: string
+          description: Creation UTC date-time of the category (YYYY-MM-DDTHH:mm:ss.SSSZ)
+          example: 2017-05-12T12:30:00Z
+        modifiedAt:
+          type: string
+          description: Last modification UTC date-time of the category (YYYY-MM-DDTHH:mm:ss.SSSZ)
+          example: 2017-05-12T12:30:00Z
+        url:
+          type: string
+          description: URL to the category
+          format: string
+          example: http://mydomain.com/category/clothing
+        isDeleted:
+          type: boolean
+          description: category deleted from the shop's database
+          format: string
+          example: true
+
+  createUpdateCategory:
+      type: object
+      required:
+      - id
+      properties:
+        id:
+          type: string
+          description: |
+            Unique Category ID as saved in the shop
+          format: email
+          example: CAT123
+        name:
+          type: string
+          description: |
+            **Mandatory in case of creation**. Name of the Category, as displayed in the shop
+          example: Electronics
+        url:
+          type: string
+          description: URL to the category
+          example: http://mydomain.com/category/electronics
+        updateEnabled:
+          type: boolean
+          description: Facilitate to update the existing category in the same request
+            (updateEnabled = true)
+          example: false
+          default: false
+        deletedAt:
+          type: string
+          description: UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) of the category deleted from the shop's database
+          example: 2017-05-12T12:30:00Z
+        isDeleted:
+          type: boolean
+          description: category deleted from the shop's database
+          example: true
+
+  createUpdateCategories:
+      type: object
+      required:
+      - id
+      properties:
+        id:
+          type: string
+          description: |
+            Unique Category ID as saved in the shop
+          format: email
+          example: CAT123
+        name:
+          type: string
+          description: |
+            **Mandatory in case of creation**. Name of the Category, as displayed in the shop
+          example: Electronics
+        url:
+          type: string
+          description: URL to the category
+          example: http://mydomain.com/category/electronics
+        deletedAt:
+          type: string
+          description: UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) of the category deleted from the shop's database
+          example: 2017-05-12T12:30:00Z
+        isDeleted:
+          type: boolean
+          description: category deleted from the shop's database
+          example: true
+
+  createUpdateBatchCategory:
+      type: object
+      required:
+      - categories
+      properties:
+        categories:
+          description: "array of categories objects"
+          type: array
+          items:
+            $ref: '#/definitions/createUpdateCategories'
+        updateEnabled:
+          type: boolean
+          description: Facilitate to update the existing categories in the same request
+            (updateEnabled = true)
+
+  createCategoryModel:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: ID of the category when a new category is created
+          format: int64
+          example: 122
+
+  createUpdateBatchCategoryModel:
+      type: object
+      properties:
+        createdCount:
+          type: integer
+          description: Number of the new created categories
+          format: int64
+          example: 7
+        updatedCount:
+          type: integer
+          description: Number of the existing categories updated
+          format: int64
+          example: 5
+
+  getProducts:
+      required:
+      - products
+      - count
+      type: object
+      properties:
+        products:
+          type: array
+          items:
+            type: object
+            allOf:
+            - $ref: '#/definitions/getProductDetails'
+        count:
+          type: integer
+          description: Number of products
+          format: int64
+          example: 17655
+
+  getProductDetails:
+      required:
+      - id
+      - name
+      - createdAt
+      - modifiedAt
+      - s3ThumbAnalytics
+      - s3ThumbEditor
+      type: object
+      properties:
+        id:
+          type: string
+          description: Product ID for which you requested the details
+          format: string
+          example: P11
+        name:
+          type: string
+          description: Name of the product for which you requested the details
+          format: string
+          example: Iphone 11
+        createdAt:
+          type: string
+          description: Creation UTC date-time of the product (YYYY-MM-DDTHH:mm:ss.SSSZ)
+          example: 2017-05-12T12:30:00Z
+        modifiedAt:
+          type: string
+          description: Last modification UTC date-time of the product (YYYY-MM-DDTHH:mm:ss.SSSZ)
+          example: 2017-05-12T12:30:00Z
+        url:
+          type: string
+          description: URL to the product
+          format: string
+          example: http://mydomain.com/product/electronics/product1
+        imageUrl:
+          type: string
+          description: Absolute URL to the cover image of the product
+          format: string
+          example: http://mydomain.com/product-absoulte-url/img.jpeg
+        sku:
+          type: string
+          description: Product identifier from the shop
+          format: string
+        price:
+          type: number
+          description: Price of the product
+          format: float
+        categories:
+          type: array
+          items:
+            type: string
+          description: Category ID-s of the product
+        parentId:
+          type: string
+          description: Parent product id of the product
+          format: string
+        s3Original:
+          type: string
+          description: S3 url of original image
+          format: string
+        s3ThumbAnalytics:
+          type: string
+          description: S3 thumbnail url of original image in 120x120 dimension for analytics section
+          format: string
+        metaInfo:
+          type: object
+          description: Meta data of product such as description, vendor, producer, stock level, etc.
+          example: {
+            "description" : "Shoes for sports",
+            "brand": "addidas"
+          }
+        s3ThumbEditor:
+          type: string
+          description: S3 thumbnail url of original image in 600x400 dimension for editor section
+          format: string
+        isDeleted:
+          type: boolean
+          description: product deleted from the shop's database
+          format: string
+          example: true
+        stock :
+          type: number
+          description: Current stock value of the product from the shop's database
+          example: 100
+
+  createUpdateProduct:
+      type: object
+      required:
+      - id
+      - name
+      properties:
+        id:
+          type: string
+          description: Product ID for which you requested the details
+          format: string
+          example: P11
+        name:
+          type: string
+          description: Mandatory in case of creation**. Name of the product for which you requested the details
+          format: string
+          example: Iphone 11
+        url:
+          type: string
+          description: URL to the product
+          format: string
+          example: http://mydomain.com/product/electronics/product1
+        imageUrl:
+          type: string
+          description: Absolute URL to the cover image of the product
+          format: string
+          example: http://mydomain.com/product-absoulte-url/img.jpeg
+        sku:
+          type: string
+          description: Product identifier from the shop
+          format: string
+        price:
+          type: number
+          description: Price of the product
+          format: float
+        categories:
+          type: array
+          items:
+            type: string
+          description: Category ID-s of the product
+        parentId:
+          type: string
+          description: Parent product id of the product
+          format: string
+        metaInfo:
+          type: object
+          additionalProperties:
+            type: string
+          description: Meta data of product such as description, vendor, producer, stock level. The size of cumulative metaInfo shall not exceed **1000 KB**. Maximum length of metaInfo object can be 20.
+          example: {
+            "description" : "Shoes for sports",
+            "brand": "addidas"
+          }
+        updateEnabled:
+          type: boolean
+          description: Facilitate to update the existing category in the same request
+            (updateEnabled = true)
+          example: false
+          default: false
+        deletedAt:
+          type: string
+          description: UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) of the product deleted from the shop's database
+          example: 2017-05-12T12:30:00Z
+        isDeleted:
+          type: boolean
+          description: product deleted from the shop's database
+          example: true
+        stock :
+          type: number
+          description: Current stock value of the product from the shop's database
+          example: 100
+
+  createUpdateBatchProducts:
+      type: object
+      required:
+      - products
+      properties:
+        products:
+          description: "array of products objects"
+          type: array
+          items:
+            $ref: '#/definitions/createUpdateProducts'
+        updateEnabled:
+          type: boolean
+          description: Facilitate to update the existing categories in the same request
+            (updateEnabled = true)
+
+  createUpdateProducts:
+      type: object
+      required:
+      - id
+      - name
+      properties:
+        id:
+          type: string
+          description: Product ID for which you requested the details
+          format: string
+          example: P11
+        name:
+          type: string
+          description: Mandatory in case of creation**. Name of the product for which you requested the details
+          format: string
+          example: Iphone 11
+        url:
+          type: string
+          description: URL to the product
+          format: string
+          example: http://mydomain.com/product/electronics/product1
+        imageUrl:
+          type: string
+          description: Absolute URL to the cover image of the product
+          format: string
+          example: http://mydomain.com/product-absoulte-url/img.jpeg
+        sku:
+          type: string
+          description: Product identifier from the shop
+          format: string
+        price:
+          type: number
+          description: Price of the product
+          format: float
+        categories:
+          type: array
+          items:
+            type: string
+          description: Category ID-s of the product
+        parentId:
+          type: string
+          description: Parent product id of the product
+          format: string
+        metaInfo:
+          type: object
+          additionalProperties:
+            type: string
+          description: Meta data of product such as description, vendor, producer, stock level. The size of cumulative metaInfo shall not exceed **1000 KB**. Maximum length of metaInfo object can be 20.
+          example: {
+            "description" : "Shoes for sports",
+            "brand": "addidas"
+          }
+        deletedAt:
+          type: string
+          description: UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) of the product deleted from the shop's database
+          example: 2017-05-12T12:30:00Z
+        isDeleted:
+          type: boolean
+          description: product deleted from the shop's database
+          example: true
+        stock :
+          type: number
+          description: Current stock value of the product from the shop's database
+          example: 100
+  createProductModel:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: ID of the Product when a new product is created
+          format: int64
+          example: 122
+  event:
+      type: object
+      required:
+      - event_name
+      - identifiers
+      properties:
+        event_name:
+          description: 'The name of the event that occurred. This is how you will find your event in Brevo. Limited to 255 characters, alphanumerical characters and - _ only.'
+          type: string
+          example: "video_played"
+        event_date:
+          description: 'Timestamp of when the event occurred (e.g. "2024-01-24T17:39:57+01:00"). If no value is passed, the timestamp of the event creation is used.'
+          type: string
+          example: "2024-02-06T20:59:23.383Z"
+        identifiers:
+          description: 'Identifies the contact associated with the event. At least one identifier is required.'
+          type: object
+          minProperties: 1
+          properties:
+            email_id:
+              type: string
+              description: 'Email Id associated with the event'
+              example: "jane.doe@example.com"
+            contact_id:
+              type: integer
+              format: int64
+              description: 'Internal unique contact ID. When present, this takes priority over all other identifiers for event attribution and contact resolution.'
+              example: 211
+            phone_id:
+              type: string
+              description: 'SMS associated with the event'
+              example: "+91xxxxxxxxxx"
+            whatsapp_id:
+              type: string
+              description: 'whatsapp associated with the event'
+              example: "+91xxxxxxxxxx"
+            landline_number_id:
+              type: string
+              description: 'landline_number associated with the event'
+              example: "+91xxxxxxxxxx"
+            ext_id:
+              type: string
+              description: 'ext_id associated with the event'
+              example: "abc123"
+        contact_properties:
+          description: 'Properties defining the state of the contact associated to this event. Useful to update contact attributes defined in your contacts database while passing the event. For example: **"FIRSTNAME": "Jane" , "AGE": 37**'
+          type: object
+          example: {
+            "AGE": 32,
+            "GENDER": "FEMALE"
+          }
+        event_properties:
+          description: 'Properties of the event. Top level properties and nested properties can be used to better segment contacts and personalise workflow conditions. The following field type are supported: string, number, boolean (true/false), date (Timestamp e.g. "2024-01-24T17:39:57+01:00"). Keys are limited to 255 characters, alphanumerical characters and - _ only. Size is limited to 50Kb.'
+          type: object
+          example: {
+            "video_title": "Brevo — The most approachable CRM suite",
+            "vide_description": "Create your free account today!",
+            "duration": 142,
+            "autoplayed": false,
+            "upload_date": "2023-11-24T12:09:10+01:00"
+          }
+        object:
+          type: object
+          description: Identifiers of the object record associated with this event. Ignored if the object type or identifier for this record does not exist on the account.
+          properties:
+            type:
+              type: string
+              description: Type of object (e.g., subscription, vehicle, etc.)
+              example: "subscription"
+            identifiers:
+              type: object
+              description: Identifiers for the object.
+              properties:
+                id:
+                  type: string
+                  description: Internal object ID
+                  example: "178140"
+                ext_id:
+                  type: string
+                  description: External object ID
+                  example: "sub-59374-linwn"
+
+  getCouponCollection:
+    required:
+      - id
+      - name
+      - defaultCoupon
+      - createdAt
+      - totalCoupons
+      - remainingCoupons
+    type: object
+    properties:
+      id:
+        description: The id of the collection.
+        type: string
+        format: uuidv4
+        example: "23befbae-1505-47a8-bd27-e30ef739f32c"
+      name:
+        description: The name of the collection.
+        type: string
+        format: uuidv4
+        example: "SummerPromotions"
+      defaultCoupon:
+        description: The default coupon of the collection.
+        type: string
+        example: 10 OFF
+      createdAt:
+        description: Datetime on which the collection was created.
+        type: string
+        format: date-time
+        example: 2023-01-06T05:03:47.053000000Z
+      totalCoupons:
+        description: Total number of coupons in the collection.
+        type: integer
+        format: int64
+        example: 10000
+      remainingCoupons:
+        description: Number of coupons that have not been sent yet.
+        type: integer
+        format: int64
+        example: 5000
+      expirationDate:
+        description: Expiration date for the coupon collection in RFC3339 format.
+        type: string
+        format: date-time
+        example: "2024-01-01T00:00:00Z"
+      remainingDaysAlert:
+        description: If present, an email notification is going to be sent the defined amount of days before the expiration date.
+        type: integer
+        example: 5
+      remainingCouponsAlert:
+        description: If present, an email notification is going to be sent when the total number of available coupons falls below the defined threshold.
+        type: integer
+        example: 5
+  createUpdateBatchProductsModel:
+      type: object
+      properties:
+        createdCount:
+          type: integer
+          description: Number of the new created products
+          format: int64
+          example: 7
+        updatedCount:
+          type: integer
+          description: Number of the existing products updated
+          format: int64
+          example: 5
+  sendWhatsappMessage:
+      required:
+      - senderNumber
+      - contactNumbers
+      type: object
+      properties:
+        templateId:
+          type: integer
+          description: ID of the template to send
+          example: 123
+        text:
+          type: string
+          description: Text to be sent as message body (will be overridden if templateId is passed in the same request)
+          example: Hi! There i am a message
+        senderNumber:
+          type: string
+          format: mobile
+          description: WhatsApp Number with country code. Example, 85264318721
+          example: 919876543210
+        # mediaUrl:
+        #   type: string
+        #   description: URL of the media to be sent
+        #   format: url
+        #   example: https://example.com/image.png
+        params:
+          type: object
+          description: Pass the set of attributes to customize the template. For example, {"FNAME":"Joe", "LNAME":"Doe"}.
+          example: {"FNAME":"Joe", "LNAME":"Doe"}
+        contactNumbers:
+          type: array
+          description: List of phone numbers of the contacts
+          items:
+            type: string
+            description: WhatsApp Number with country code. Example, 85264318721
+            format: mobile
+            example: 919876543210
+  getWhatsappEventReport:
+      type: object
+      properties:
+        events:
+          type: array
+          items:
+            required:
+            - contactNumber
+            - date
+            - messageId
+            - event
+            - senderNumber
+            type: object
+            properties:
+              contactNumber:
+                type: string
+                format: mobile
+                description: WhatsApp Number with country code. Example, 85264318721
+                example: 919876543210
+              date:
+                type: string
+                description: UTC date-time on which the event has been generated
+                example: 2017-03-12T12:30:00Z
+              messageId:
+                type: string
+                description: Message ID which generated the event
+                example: 23befbae-1505-47a8-bd27-e30ef739f32c
+              event:
+                type: string
+                description: Event which occurred
+                example: delivered
+                enum:
+                - sent
+                - delivered
+                - read
+                - error
+                - unsubscribe
+                - reply
+                - soft-bounce
+              reason:
+                type: string
+                description: Reason for the event (will be there in case of `error` and `soft-bounce` events)
+                example: 23befbae-1505-47a8-bd27-e30ef739f32c
+              body:
+                type: string
+                description: Text of the reply (will be there only in case of `reply` event with text)
+                example: "Hi! I am a reply"
+              mediaUrl:
+                type: string
+                format: url
+                description: Url of the media reply (will be there only in case of `reply` event with media)
+                example: "https://example.com/media.png"
+              senderNumber:
+                type: string
+                format: mobile
+                description: WhatsApp Number with country code. Example, 85264318721
+                example: 919876543210
+  getExternalFeedByUUID:
+    type: object
+    required:
+      - id
+      - name
+      - url
+      - authType
+      - headers
+      - maxRetries
+      - cache
+      - createdAt
+      - modifiedAt
+    properties:
+      id:
+        description: 'ID of the feed'
+        type: string
+        format: uuidv4
+        example: 54377442-20a2-4c20-b761-d636c72de7b7
+      name:
+        description: 'Name of the feed'
+        type: string
+        example: New feed
+      url:
+        description: 'URL of the feed'
+        type: string
+        format: url
+        example: http://requestb.in/173lyyx1
+      authType:
+        type: string
+        enum: [basic, token, noAuth]
+        description: >
+          Auth type of the feed:
+          * `basic`
+          * `token`
+          * `noAuth`
+      username:
+        type: string
+        description: Username for authType `basic`
+        example: user
+      password:
+        type: string
+        description: Password for authType `basic`
+        example: password
+      token:
+        type: string
+        description: Token for authType `token`
+        example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+      headers:
+        type: array
+        description: Custom headers for the feed
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the header
+              example: userId
+            value:
+              type: string
+              description: Value of the header
+              example: 'user12345'
+      maxRetries:
+        type: integer
+        description: Maximum number of retries on the feed url
+        example: 5
+        minimum: 0
+        maximum: 5
+        default: 5
+      cache:
+        type: boolean
+        description: Toggle caching of feed url response
+        example: true
+      createdAt:
+        description: 'Datetime on which the feed was created'
+        type: string
+        format: date-time
+        example: '2022-10-06T05:03:47.053000000Z'
+      modifiedAt:
+        description: 'Datetime on which the feed was modified'
+        type: string
+        format: date-time
+        example: '2022-10-06T05:03:47.053000000Z'
+  getAllExternalFeeds:
+    type: object
+    properties:
+      count:
+        type: integer
+        description: 'Total number of batches'
+      feeds:
+        type: array
+        items:
+          type: object
+          required:
+            - id
+            - name
+            - url
+            - authType
+            - headers
+            - maxRetries
+            - cache
+            - createdAt
+            - modifiedAt
+          properties:
+            id:
+              description: 'ID of the feed'
+              type: string
+              format: uuidv4
+              example: 54377442-20a2-4c20-b761-d636c72de7b7
+            name:
+              description: 'Name of the feed'
+              type: string
+              example: New feed
+            url:
+              description: 'URL of the feed'
+              type: string
+              format: url
+              example: http://requestb.in/173lyyx1
+            authType:
+              type: string
+              enum: [basic, token, noAuth]
+              description: >
+                Auth type of the feed:
+                * `basic`
+                * `token`
+                * `noAuth`
+            username:
+              type: string
+              description: Username for authType `basic`
+              example: user
+            password:
+              type: string
+              description: Password for authType `basic`
+              example: password
+            token:
+              type: string
+              description: Token for authType `token`
+              example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+            headers:
+              type: array
+              description: Custom headers for the feed
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Name of the header
+                    example: userId
+                  value:
+                    type: string
+                    description: Value of the header
+                    example: 'user12345'
+            maxRetries:
+              type: integer
+              description: Maximum number of retries on the feed url
+              example: 5
+              minimum: 0
+              maximum: 5
+              default: 5
+            cache:
+              type: boolean
+              description: Toggle caching of feed url response
+              example: true
+            createdAt:
+              description: 'Datetime on which the feed was created'
+              type: string
+              format: date-time
+              example: '2022-10-06T05:03:47.053000000Z'
+            modifiedAt:
+              description: 'Datetime on which the feed was modified'
+              type: string
+              format: date-time
+              example: '2022-10-06T05:03:47.053000000Z'
+  createExternalFeed:
+    required:
+    - name
+    - url
+    type: object
+    properties:
+      name:
+        type: string
+        description: Name of the feed
+        example: New feed
+      url:
+        type: string
+        description: URL of the feed
+        format: url
+        example: http://requestb.in/173lyyx1
+      authType:
+        type: string
+        enum: [basic, token, noAuth]
+        default: noAuth
+        description: >
+          Auth type of the feed:
+            * `basic`
+            * `token`
+            * `noAuth`
+      username:
+        type: string
+        description: Username for authType `basic`
+        example: user
+      password:
+        type: string
+        description: Password for authType `basic`
+        example: password
+      token:
+        type: string
+        description: Token for authType `token`
+        example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+      headers:
+        type: array
+        description: Custom headers for the feed
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the header
+              example: userId
+            value:
+              type: string
+              description: Value of the header
+              example: 'user12345'
+        example:
+          - name: header1
+            value: value1
+          - name: header2
+            value: value2
+      maxRetries:
+        type: integer
+        description: Maximum number of retries on the feed url
+        example: 5
+        minimum: 0
+        maximum: 5
+        default: 5
+      cache:
+        type: boolean
+        description: Toggle caching of feed url response
+        example: true
+        default: false
+  updateExternalFeed:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Name of the feed
+        example: New feed
+      url:
+        type: string
+        description: URL of the feed
+        format: url
+        example: http://requestb.in/173lyyx1
+      authType:
+        type: string
+        enum: [basic, token, noAuth]
+        description: >
+          Auth type of the feed:
+            * `basic`
+            * `token`
+            * `noAuth`
+      username:
+        type: string
+        description: Username for authType `basic`
+        example: user
+      password:
+        type: string
+        description: Password for authType `basic`
+        example: password
+      token:
+        type: string
+        description: Token for authType `token`
+        example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+      headers:
+        type: array
+        description: Custom headers for the feed
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the header
+              example: userId
+            value:
+              type: string
+              description: Value of the header
+              example: 'user12345'
+        example:
+          - name: header1
+            value: value1
+          - name: header2
+            value: value2
+      maxRetries:
+        type: integer
+        description: Maximum number of retries on the feed url
+        example: 5
+        minimum: 0
+        maximum: 5
+        default: 5
+      cache:
+        type: boolean
+        description: Toggle caching of feed url response
+        example: true
+        default: false
+  exportWebhooksHistory:
+      required:
+      - event
+      - notifyURL
+      - type
+      type: object
+      properties:
+        days:
+          type: integer
+          description: Number of days in the past including today (positive integer). _Not compatible with 'startDate' and 'endDate'_
+          example: 7
+        startDate:
+          type: string
+          description: Mandatory if endDate is used. Starting date of the history (YYYY-MM-DD). Must be lower than equal to endDate
+          example: 2023-02-13
+        endDate:
+          type: string
+          description: Mandatory if startDate is used. Ending date of the report (YYYY-MM-DD). Must be greater than equal to startDate
+          example: 2023-02-17
+        sort:
+          type: string
+          description: Sorting order of records (asc or desc)
+          example: desc
+        type:
+          type: string
+          description: Filter the history based on webhook type
+          example: transactional
+          enum:
+           - transactional
+           - marketing
+        event:
+          type: string
+          description: Filter the history for a specific event type
+          example: request
+          enum:
+           - invalid_parameter
+           - missing_parameter
+           - hardBounce
+           - softBounce
+           - delivered
+           - spam
+           - request
+           - opened
+           - click
+           - invalid
+           - deferred
+           - blocked
+           - unsubscribed
+           - error
+           - uniqueOpened
+           - loadedByProxy
+           - allEvents
+        notifyURL:
+          type: string
+          description: Webhook URL to receive CSV file link
+          example: https://brevo.com
+        webhookId:
+          type: integer
+          description: Filter the history for a specific webhook id
+          example: 2345
+        email:
+          type: string
+          description: Filter the history for a specific email
+          example: example@brevo.com
+        messageId:
+          type: integer
+          description: Filter the history for a specific message id. Applicable only for transactional webhooks.
+          example: <23befbae-1505-47a8-bd27-e30ef739f32c@fr.sib>
+
+  createPaymentRequest:
+    required:
+      - reference
+      - contactId
+      - cart
+    type: object
+    properties:
+      reference:
+        type: string
+        description: |
+          Reference of the payment request, it will appear on the payment page.
+        example: 'Invoice #INV0001'
+      cart:
+        $ref: '#/definitions/cart'
+      contactId:
+        type: integer
+        description: |
+          Brevo ID of the contact requested to pay.
+        format: int64
+        example: 43
+      description:
+        type: string
+        description: |
+          description of payment request.
+        example: Shipping Cost for sending bottles to NYC
+      notification:
+        $ref: '#/definitions/notification'
+      configuration:
+        $ref: '#/definitions/configuration'
+
+  configuration:
+    description: |
+      Optional. Redirect contact to a custom success page once payment is successful. If empty the default Brevo page will be displayed once a payment is validated
+    required:
+      - customSuccessUrl
+    properties:
+      customSuccessUrl:
+        type: string
+        format: url
+        description: |
+          Absolute URL of the custom success page.
+        example: https://my-company.com/payment-success
+
+
+
+  cart:
+    type: object
+    description: |
+      Specify the payment currency and amount.
+    required:
+      - currency
+      - specificAmount
+    properties:
+      currency:
+        type: string
+        description: |
+          Currency code for the payment amount.
+        example: EUR
+        enum:
+          - EUR
+      specificAmount:
+        type: integer
+        description: |
+          Payment amount, in cents.
+           e.g. if you want to request €12.00, then the amount in cents is 1200.
+        format: int64
+        example: 1200
+
+  notification:
+    description: |
+        Optional. Use this object if you want to let Brevo send an email to the contact, with the payment request URL. If empty, no notifications (message and reminders) will be sent.
+    required:
+      - channel
+      - text
+    type: object
+    properties:
+      channel:
+        type: string
+        description: |
+           Channel used to send the notifications.
+        example: email
+        enum:
+          - email
+      text:
+        type: string
+        description: |
+           Use this field if you want to give more context to your contact about the payment request.
+        example: Please pay for your yoga class.
+
+  getPaymentRequest:
+    type: object
+    properties:
+      reference:
+        type: string
+        description: |
+            Reference of the payment request, it will appear on the payment page.
+        example: |
+            Invoice #INV0001
+      status:
+        type: string
+        description: Status of the payment request.
+        enum:
+          - created
+          - sent
+          - reminderSent
+            - paid
+        example: paid
+      configuration:
+        $ref: '#/definitions/configuration'
+      contactId:
+        type: integer
+        description: |
+            Brevo ID of the contact requested to pay.
+        format: int64
+        example: 43
+      numberOfRemindersSent:
+        type: integer
+        description: |
+          number of reminders sent.
+        format: int64
+        example: 5
+      cart:
+        $ref: '#/definitions/cart'
+      notification:
+        $ref: '#/definitions/notification'
+
+    required:
+      - reference
+      - status
+      - cart
+      - notification
+


### PR DESCRIPTION
Summary                                                                                                                                                            
         
  - Fixed incorrect tag field type in SendTransacSms — the tag field was typed as SendTransacSmsTag (a generated wrapper object with a field property), which would
  have incorrectly serialized the request body as {"tag": {"field": "accountValidation"}}. The Brevo API expects a plain string value, e.g. {"tag":                    
  "accountValidation"}. The field is now typed as String.
  - Updated the builder method tag(String), getter getTag(), and setter setTag(String) accordingly.                                                                    
  - Updated @ApiModelProperty description to accurately reflect that the tag value is a string (e.g. "accountValidation").                                             
  - SendTransacSmsTag.java is retained as generated by the swagger codegen but is no longer used by SendTransacSms.                                                    
                                                                                                                                                                       
Test Plan                                                                                                                                                            
                                                                                                                                                                     
  - Verify SendTransacSms.tag serializes correctly as a plain string in the JSON request body                                                                          
  - Confirm sendTransacSms API call succeeds with a string tag value (e.g. "accountValidation")
  - Confirm build compiles without errors (mvn compile)  