### PR TITLE
fix: remove misplaced maven-gpg-plugin from dependencies  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,12 +97,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.1.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <version>1.3.2</version>


### PR DESCRIPTION
Summary                                                                                                                                                              
                                                                                                                                                                     
  - Removed maven-gpg-plugin (v3.1.0) from the <dependencies> section in pom.xml                                                                                       
  - This plugin was incorrectly declared as a dependency instead of being configured under <build><plugins>, which could cause unintended classpath pollution or build
  issues                                                                                                                                                               
                                                                                                                                                                     
  Test plan                                                                                                                                                            
                                                                                                                                                                     
  - Verify Maven build completes successfully after the change
  - Confirm GPG signing (if used) still works via the plugin configured in <build><plugins>
  - Run mvn clean install to ensure no dependency resolution errors  